### PR TITLE
Implemented task for recreating strm files for all available media

### DIFF
--- a/backend/Api/Controllers/RecreateStrmFiles/RecreateStrmFilesController.cs
+++ b/backend/Api/Controllers/RecreateStrmFiles/RecreateStrmFilesController.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Tasks;
+using NzbWebDAV.Websocket;
+
+namespace NzbWebDAV.Api.Controllers;
+
+[ApiController]
+[Route("api/recreate-strm-files")]
+public class RecreateStrmFiles(
+    ConfigManager configManager,
+    DavDatabaseClient dbClient,
+    WebsocketManager websocketManager
+) : BaseApiController
+{
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        var task = new RecreateStrmFilesTask(configManager, dbClient, websocketManager);
+        var executed = await task.Execute().ConfigureAwait(false);
+        return Ok(executed);
+    }
+}

--- a/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
+++ b/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
@@ -1,10 +1,8 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using NzbWebDAV.Api.Controllers.GetWebdavItem;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Utils;
-using NzbWebDAV.WebDav;
 
 namespace NzbWebDAV.Queue.PostProcessors;
 
@@ -19,38 +17,6 @@ public class CreateStrmFilesPostProcessor(ConfigManager configManager, DavDataba
             .Where(x => x.Type != DavItem.ItemType.Directory)
             .Where(x => FilenameUtil.IsVideoFile(x.Name));
         foreach (var videoItem in videoItems)
-            await CreateStrmFileAsync(videoItem).ConfigureAwait(false);
-    }
-
-    private async Task CreateStrmFileAsync(DavItem davItem)
-    {
-        // create necessary directories if they don't already exist
-        var strmFilePath = GetStrmFilePath(davItem);
-        var directoryName = Path.GetDirectoryName(strmFilePath);
-        if (directoryName != null)
-            await Task.Run(() => Directory.CreateDirectory(directoryName)).ConfigureAwait(false);
-
-        // create the strm file
-        var targetUrl = GetStrmTargetUrl(davItem);
-        await File.WriteAllTextAsync(strmFilePath, targetUrl).ConfigureAwait(false);
-    }
-
-    private string GetStrmFilePath(DavItem davItem)
-    {
-        var path = davItem.Path + ".strm";
-        var parts = path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        return Path.Join(configManager.GetStrmCompletedDownloadDir(), Path.Join(parts[2..]));
-    }
-
-    private string GetStrmTargetUrl(DavItem davItem)
-    {
-        var baseUrl = configManager.GetBaseUrl();
-        if (baseUrl.EndsWith('/')) baseUrl = baseUrl.TrimEnd('/');
-        var pathUrl = DatabaseStoreSymlinkFile.GetTargetPath(davItem.Id, "", '/');
-        if (pathUrl.StartsWith('/')) pathUrl = pathUrl.TrimStart('/');
-        var strmKey = configManager.GetStrmKey();
-        var downloadKey = GetWebdavItemRequest.GenerateDownloadKey(strmKey, pathUrl);
-        var extension = Path.GetExtension(davItem.Name).ToLower().TrimStart('.');
-        return $"{baseUrl}/view/{pathUrl}?downloadKey={downloadKey}&extension={extension}";
+            await StrmFileUtil.CreateStrmFileAsync(configManager, videoItem).ConfigureAwait(false);
     }
 }

--- a/backend/Queue/QueueManager.cs
+++ b/backend/Queue/QueueManager.cs
@@ -151,7 +151,7 @@ public class QueueManager : IDisposable
             ProgressPercentage = 0,
             CancellationTokenSource = cts
         };
-        var debounce = DebounceUtil.CreateDebounce(TimeSpan.FromMilliseconds(200));
+        var debounce = DebounceUtil.CreateDebounce();
         progressHook.ProgressChanged += (_, progress) =>
         {
             inProgressQueueItem.ProgressPercentage = progress;

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -120,7 +120,7 @@ public class HealthCheckService
 
             // setup progress tracking
             var progressHook = new Progress<int>();
-            var debounce = DebounceUtil.CreateDebounce(TimeSpan.FromMilliseconds(200));
+            var debounce = DebounceUtil.CreateDebounce();
             progressHook.ProgressChanged += (_, progress) =>
             {
                 var message = $"{davItem.Id}|{progress}";

--- a/backend/Tasks/BaseTask.cs
+++ b/backend/Tasks/BaseTask.cs
@@ -1,6 +1,11 @@
-﻿namespace NzbWebDAV.Tasks;
+﻿using NzbWebDAV.Websocket;
 
-public abstract class BaseTask
+namespace NzbWebDAV.Tasks;
+
+public abstract class BaseTask(
+    WebsocketManager websocketManager,
+    WebsocketTopic reportTopic
+)
 {
     protected abstract Task ExecuteInternal();
 
@@ -29,5 +34,10 @@ public abstract class BaseTask
         // and wait for it to finish.
         await task.ConfigureAwait(false);
         return true;
+    }
+
+    protected void Report(string message)
+    {
+        _ = websocketManager.SendMessage(reportTopic, message);
     }
 }

--- a/backend/Tasks/BaseTask.cs
+++ b/backend/Tasks/BaseTask.cs
@@ -1,4 +1,5 @@
-﻿using NzbWebDAV.Websocket;
+﻿using NzbWebDAV.Utils;
+using NzbWebDAV.Websocket;
 
 namespace NzbWebDAV.Tasks;
 
@@ -11,6 +12,9 @@ public abstract class BaseTask(
 
     private static readonly SemaphoreSlim Semaphore = new(1, 1);
     private static Task? _runningTask;
+
+    private static Action<Action> Debounce => field ??= DebounceUtil.CreateDebounce();
+
 
     public async Task<bool> Execute()
     {
@@ -39,5 +43,10 @@ public abstract class BaseTask(
     protected void Report(string message)
     {
         _ = websocketManager.SendMessage(reportTopic, message);
+    }
+
+    protected void ReportDebounced(string message)
+    {
+        Debounce(() => Report(message));
     }
 }

--- a/backend/Tasks/RecreateStrmFilesTask.cs
+++ b/backend/Tasks/RecreateStrmFilesTask.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Utils;
+using NzbWebDAV.Websocket;
+using Serilog;
+
+namespace NzbWebDAV.Tasks;
+
+public class RecreateStrmFilesTask(
+    ConfigManager configManager,
+    DavDatabaseClient dbClient,
+    WebsocketManager websocketManager
+) : BaseTask(websocketManager, WebsocketTopic.RecreateStrmFilesTaskProgress)
+{
+    public async Task RecreateStrmFiles()
+    {
+        Report("Collecting all strm file candidates...");
+
+        var files = dbClient.Ctx.Items
+            .Where(x => x.Type != DavItem.ItemType.Directory)
+            .AsAsyncEnumerable()
+            .Where(x => FilenameUtil.IsVideoFile(x.Name));
+        var fileCount = await files.CountAsync();
+        var progress = 0;
+
+        await foreach (var file in files)
+        {
+            ReportDebounced($"Creating strm file {++progress} / {fileCount}.");
+            await StrmFileUtil.CreateStrmFileAsync(configManager, file);
+        }
+
+        Report($"Done. Created {fileCount} strm files.");
+    }
+
+    protected override async Task ExecuteInternal()
+    {
+        try
+        {
+            await RecreateStrmFiles().ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            Report($"Failed: {e.Message}");
+            Log.Error(e, "Failed to recreate strm files.");
+        }
+    }
+}

--- a/backend/Tasks/RemoveUnlinkedFilesTask.cs
+++ b/backend/Tasks/RemoveUnlinkedFilesTask.cs
@@ -14,7 +14,7 @@ public class RemoveUnlinkedFilesTask(
     DavDatabaseClient dbClient,
     WebsocketManager websocketManager,
     bool isDryRun
-) : BaseTask
+) : BaseTask(websocketManager, WebsocketTopic.CleanupTaskProgress)
 {
     private static List<string> _allRemovedPaths = [];
 
@@ -112,11 +112,6 @@ public class RemoveUnlinkedFilesTask(
         return OrganizedLinksUtil.GetLibraryDavItemLinks(configManager)
             .Select(x => x.DavItemId)
             .ToHashSet();
-    }
-
-    private void Report(string message)
-    {
-        _ = websocketManager.SendMessage(WebsocketTopic.CleanupTaskProgress, message);
     }
 
     public static string GetAuditReport()

--- a/backend/Tasks/StrmToSymlinksTask.cs
+++ b/backend/Tasks/StrmToSymlinksTask.cs
@@ -33,7 +33,6 @@ public class StrmToSymlinksTask(
     private async Task ConvertAllStrmFilesToSymlinks(CancellationToken token)
     {
         var completedCount = 0;
-        var debounce = DebounceUtil.CreateDebounce(TimeSpan.FromMilliseconds(200));
         var batches = OrganizedLinksUtil.GetLibraryDavItemLinks(configManager)
             .Where(x => x.SymlinkOrStrmInfo is SymlinkAndStrmUtil.StrmInfo)
             .ToBatches(batchSize: 100);
@@ -47,7 +46,7 @@ public class StrmToSymlinksTask(
         void OnItemCompleted()
         {
             completedCount++;
-            debounce(() => ReportProgress("Scanning library for strm files...", completedCount));
+            ReportProgress("Scanning library for strm files...", completedCount, true);
         }
     }
 
@@ -97,8 +96,9 @@ public class StrmToSymlinksTask(
         return queryParams.Get("extension");
     }
 
-    private void ReportProgress(string message, int completedCount)
+    private void ReportProgress(string message, int completedCount, bool debounce = false)
     {
-        Report($"{message}\nConverted: {completedCount} strm file(s) to symlinks.");
+        Action<string> report = debounce ? ReportDebounced : Report;
+        report($"{message}\nConverted: {completedCount} strm file(s) to symlinks.");
     }
 }

--- a/backend/Tasks/StrmToSymlinksTask.cs
+++ b/backend/Tasks/StrmToSymlinksTask.cs
@@ -14,7 +14,7 @@ public class StrmToSymlinksTask(
     ConfigManager configManager,
     DavDatabaseClient dbClient,
     WebsocketManager websocketManager
-) : BaseTask
+) : BaseTask(websocketManager, WebsocketTopic.StrmToSymlinksTaskProgress)
 {
     protected override async Task ExecuteInternal()
     {
@@ -95,11 +95,6 @@ public class StrmToSymlinksTask(
         if (link.SymlinkOrStrmInfo is not SymlinkAndStrmUtil.StrmInfo strmInfo) return null;
         var queryParams = HttpUtility.ParseQueryString(new Uri(strmInfo.TargetUrl).Query);
         return queryParams.Get("extension");
-    }
-
-    private void Report(string message)
-    {
-        _ = websocketManager.SendMessage(WebsocketTopic.StrmToSymlinksTaskProgress, message);
     }
 
     private void ReportProgress(string message, int completedCount)

--- a/backend/Utils/DebounceUtil.cs
+++ b/backend/Utils/DebounceUtil.cs
@@ -2,6 +2,11 @@ namespace NzbWebDAV.Utils;
 
 public static class DebounceUtil
 {
+    public static Action<Action> CreateDebounce(int milliseconds = 200)
+    {
+        return CreateDebounce(TimeSpan.FromMilliseconds(milliseconds));
+    }
+
     public static Action<Action> CreateDebounce(TimeSpan timespan)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(timespan, TimeSpan.Zero);

--- a/backend/Utils/StrmFileUtil.cs
+++ b/backend/Utils/StrmFileUtil.cs
@@ -1,0 +1,42 @@
+using NzbWebDAV.Api.Controllers.GetWebdavItem;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.WebDav;
+
+namespace NzbWebDAV.Utils;
+
+public static class StrmFileUtil
+{
+
+    public static async Task CreateStrmFileAsync(ConfigManager configManager, DavItem davItem)
+    {
+        // create necessary directories if they don't already exist
+        var strmFilePath = GetStrmFilePath(configManager, davItem);
+        var directoryName = Path.GetDirectoryName(strmFilePath);
+        if (directoryName != null)
+            await Task.Run(() => Directory.CreateDirectory(directoryName)).ConfigureAwait(false);
+
+        // create the strm file
+        var targetUrl = GetStrmTargetUrl(configManager, davItem);
+        await File.WriteAllTextAsync(strmFilePath, targetUrl).ConfigureAwait(false);
+    }
+
+    public static string GetStrmFilePath(ConfigManager configManager, DavItem davItem)
+    {
+        var path = davItem.Path + ".strm";
+        var parts = path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return Path.Join(configManager.GetStrmCompletedDownloadDir(), Path.Join(parts[2..]));
+    }
+
+    public static string GetStrmTargetUrl(ConfigManager configManager, DavItem davItem)
+    {
+        var baseUrl = configManager.GetBaseUrl();
+        if (baseUrl.EndsWith('/')) baseUrl = baseUrl.TrimEnd('/');
+        var pathUrl = DatabaseStoreSymlinkFile.GetTargetPath(davItem.Id, "", '/');
+        if (pathUrl.StartsWith('/')) pathUrl = pathUrl.TrimStart('/');
+        var strmKey = configManager.GetStrmKey();
+        var downloadKey = GetWebdavItemRequest.GenerateDownloadKey(strmKey, pathUrl);
+        var extension = Path.GetExtension(davItem.Name).ToLower().TrimStart('.');
+        return $"{baseUrl}/view/{pathUrl}?downloadKey={downloadKey}&extension={extension}";
+    }
+}

--- a/backend/Websocket/WebsocketTopic.cs
+++ b/backend/Websocket/WebsocketTopic.cs
@@ -7,6 +7,7 @@ public class WebsocketTopic
     public static readonly WebsocketTopic SymlinkTaskProgress = new("stp", TopicType.State);
     public static readonly WebsocketTopic CleanupTaskProgress = new("ctp", TopicType.State);
     public static readonly WebsocketTopic StrmToSymlinksTaskProgress = new("st2sy", TopicType.State);
+    public static readonly WebsocketTopic RecreateStrmFilesTaskProgress = new("crst", TopicType.State);
     public static readonly WebsocketTopic QueueItemStatus = new("qs", TopicType.State);
     public static readonly WebsocketTopic QueueItemProgress = new("qp", TopicType.State);
     public static readonly WebsocketTopic HealthItemStatus = new("hs", TopicType.State);

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -38,7 +38,7 @@ export function Maintenance({ savedConfig }: MaintenanceProps) {
                         Export all available Media to Strm Files
                     </Accordion.Header>
                     <Accordion.Body className={styles.accordionBody}>
-                        <RecreateStrmFiles savedConfig={savedConfig} />
+                        <RecreateStrmFiles />
                     </Accordion.Body>
                 </Accordion.Item>
 

--- a/frontend/app/routes/settings/maintenance/maintenance.tsx
+++ b/frontend/app/routes/settings/maintenance/maintenance.tsx
@@ -2,6 +2,7 @@ import { Accordion } from "react-bootstrap";
 import styles from "./maintenance.module.css"
 import { RemoveUnlinkedFiles } from "./remove-unlinked-files/remove-unlinked-files";
 import { ConvertStrmToSymlinks } from "./strm-to-symlinks/strm-to-symlinks";
+import { RecreateStrmFiles } from "./recreate-strm-files/recreate-strm-files";
 
 type MaintenanceProps = {
     savedConfig: Record<string, string>
@@ -28,6 +29,16 @@ export function Maintenance({ savedConfig }: MaintenanceProps) {
                     </Accordion.Header>
                     <Accordion.Body className={styles.accordionBody}>
                         <ConvertStrmToSymlinks savedConfig={savedConfig} />
+                    </Accordion.Body>
+                </Accordion.Item>
+
+
+                <Accordion.Item className={styles.accordionItem} eventKey="recreate-strm-files">
+                    <Accordion.Header className={styles.accordionHeader}>
+                        Export all available Media to Strm Files
+                    </Accordion.Header>
+                    <Accordion.Body className={styles.accordionBody}>
+                        <RecreateStrmFiles savedConfig={savedConfig} />
                     </Accordion.Body>
                 </Accordion.Item>
 

--- a/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.module.css
+++ b/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.module.css
@@ -1,0 +1,42 @@
+.container {
+    max-width: 600px;
+}
+
+.task {
+    background-color: #02181d;
+    padding: 5px;
+    color: #dee2e6;
+}
+
+.alert {
+    margin-top: 8px;
+}
+
+.run {
+    margin-top: 12px;
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+    align-items: center;
+}
+
+.run-button {
+    flex-shrink: 0;
+}
+
+.dryrun-button {
+    padding: 0 5px;
+}
+
+.task-progress {
+    font-size:12px;
+    white-space: pre-line;
+}
+
+.list {
+    margin-bottom: 0;
+}
+
+.list-item {
+    margin-top: 5px
+}

--- a/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.module.css
+++ b/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.module.css
@@ -1,15 +1,7 @@
-.container {
-    max-width: 600px;
-}
-
 .task {
     background-color: #02181d;
     padding: 5px;
     color: #dee2e6;
-}
-
-.alert {
-    margin-top: 8px;
 }
 
 .run {
@@ -24,19 +16,7 @@
     flex-shrink: 0;
 }
 
-.dryrun-button {
-    padding: 0 5px;
-}
-
 .task-progress {
     font-size:12px;
     white-space: pre-line;
-}
-
-.list {
-    margin-bottom: 0;
-}
-
-.list-item {
-    margin-top: 5px
 }

--- a/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.module.css.d.ts
+++ b/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.module.css.d.ts
@@ -1,0 +1,14 @@
+declare const styles: {
+  readonly "container": string;
+  readonly "task": string;
+  readonly "title": string;
+  readonly "run": string;
+  readonly "run-button": string;
+  readonly "dryrun-button": string;
+  readonly "task-progress": string;
+  readonly "list": string;
+  readonly "list-item": string;
+  readonly "alert": string;
+};
+export = styles;
+

--- a/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.module.css.d.ts
+++ b/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.module.css.d.ts
@@ -1,14 +1,7 @@
 declare const styles: {
-  readonly "container": string;
   readonly "task": string;
-  readonly "title": string;
   readonly "run": string;
   readonly "run-button": string;
-  readonly "dryrun-button": string;
   readonly "task-progress": string;
-  readonly "list": string;
-  readonly "list-item": string;
-  readonly "alert": string;
 };
 export = styles;
-

--- a/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.tsx
+++ b/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.tsx
@@ -1,25 +1,20 @@
-import { Alert, Button, Form } from "react-bootstrap";
+import { Button, Form } from "react-bootstrap";
 import styles from "./recreate-strm-files.module.css";
 import { useCallback, useEffect, useState } from "react";
 import { receiveMessage } from "~/utils/websocket-util";
 
 const cleanupTaskTopic = { 'crst': 'state' };
 
-type RecreateStrmFilesProps = {
-    savedConfig: Record<string, string>
-};
-
-export function RecreateStrmFiles({ savedConfig }: RecreateStrmFilesProps) {
+export function RecreateStrmFiles() {
     // stateful variables
     const [connected, setConnected] = useState<boolean>(false);
     const [progress, setProgress] = useState<string | null>(null);
     const [isFetching, setIsFetching] = useState<boolean>(false);
 
     // derived variables
-    const completeDlDir = savedConfig["api.completed-downloads-dir"];
     const isFinished = progress?.startsWith("Done") || progress?.startsWith("Failed");
     const isRunning = !isFinished && (isFetching || progress !== null);
-    const isRunButtonEnabled = !!completeDlDir && connected && !isRunning;
+    const isRunButtonEnabled = connected && !isRunning;
     const runButtonVariant = isRunButtonEnabled ? 'success' : 'secondary';
     const runButtonLabel = isRunning ? "⌛ Running.." : '▶ Run Task';
 
@@ -47,17 +42,6 @@ export function RecreateStrmFiles({ savedConfig }: RecreateStrmFilesProps) {
 
     return (
         <>
-            {!completeDlDir &&
-                <Alert className={styles.alert} variant="warning">
-                    Warning
-                    <ul className={styles.list}>
-                        <li className={styles["list-item"]}>
-                            You must first configure the Completed Downloads Directory setting before running this task.
-                            Head over to the SABnzbd tab with selected 'STRM Files' Import Strategy.
-                        </li>
-                    </ul>
-                </Alert>
-            }
             <div className={styles.task}>
                 <Form.Group>
                     <div className={styles.run}>

--- a/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.tsx
+++ b/frontend/app/routes/settings/maintenance/recreate-strm-files/recreate-strm-files.tsx
@@ -1,0 +1,84 @@
+import { Alert, Button, Form } from "react-bootstrap";
+import styles from "./recreate-strm-files.module.css";
+import { useCallback, useEffect, useState } from "react";
+import { receiveMessage } from "~/utils/websocket-util";
+
+const cleanupTaskTopic = { 'crst': 'state' };
+
+type RecreateStrmFilesProps = {
+    savedConfig: Record<string, string>
+};
+
+export function RecreateStrmFiles({ savedConfig }: RecreateStrmFilesProps) {
+    // stateful variables
+    const [connected, setConnected] = useState<boolean>(false);
+    const [progress, setProgress] = useState<string | null>(null);
+    const [isFetching, setIsFetching] = useState<boolean>(false);
+
+    // derived variables
+    const completeDlDir = savedConfig["api.completed-downloads-dir"];
+    const isFinished = progress?.startsWith("Done") || progress?.startsWith("Failed");
+    const isRunning = !isFinished && (isFetching || progress !== null);
+    const isRunButtonEnabled = !!completeDlDir && connected && !isRunning;
+    const runButtonVariant = isRunButtonEnabled ? 'success' : 'secondary';
+    const runButtonLabel = isRunning ? "⌛ Running.." : '▶ Run Task';
+
+    // effects
+    useEffect(() => {
+        let ws: WebSocket;
+        let disposed = false;
+        function connect() {
+            ws = new WebSocket(window.location.origin.replace(/^http/, 'ws'));
+            ws.onmessage = receiveMessage((_, message) => setProgress(message));
+            ws.onopen = () => { setConnected(true); ws.send(JSON.stringify(cleanupTaskTopic)); }
+            ws.onclose = () => { !disposed && setTimeout(() => connect(), 1000); setProgress(null) };
+            ws.onerror = () => { ws.close() };
+            return () => { disposed = true; ws.close(); }
+        }
+        return connect();
+    }, [setProgress, setConnected]);
+
+    // events
+    const onRun = useCallback(async () => {
+        setIsFetching(true);
+        await fetch("/api/recreate-strm-files");
+        setIsFetching(false);
+    }, [setIsFetching]);
+
+    return (
+        <>
+            {!completeDlDir &&
+                <Alert className={styles.alert} variant="warning">
+                    Warning
+                    <ul className={styles.list}>
+                        <li className={styles["list-item"]}>
+                            You must first configure the Completed Downloads Directory setting before running this task.
+                            Head over to the SABnzbd tab with selected 'STRM Files' Import Strategy.
+                        </li>
+                    </ul>
+                </Alert>
+            }
+            <div className={styles.task}>
+                <Form.Group>
+                    <div className={styles.run}>
+                        <Button
+                            className={styles["run-button"]}
+                            variant={runButtonVariant}
+                            onClick={onRun}
+                            disabled={!isRunButtonEnabled}
+                        >
+                            {runButtonLabel}
+                        </Button>
+                        <div className={styles["task-progress"]}>
+                            {progress}
+                        </div>
+                    </div>
+                    <Form.Text id="cleanup-task-progress-help" muted>
+                        <br />
+                        This task will recreate *.strm files for all available media using the current settings.
+                    </Form.Text>
+                </Form.Group>
+            </div>
+        </>
+    );
+}


### PR DESCRIPTION
This task will recreate *.strm files for all available media using the current settings.

I had some problems with Radarr / Sonarr, where it lost meta data of the imported files.
These were extracted from the file names. Reimporting can fix that.

It also allows changing the base url of the strm files or fixing accidentally overwritten files without having to download them again.

This could also be implemented for symlinks, but I don't use them atm and before I invest time into it, I would like to see some of my PRs merged. ;)

Disclaimer: No AI was used in this pull request.