### PR TITLE
feat(nntp): playback streaming timeout fast-fail and retry logic

### DIFF
--- a/backend/Clients/Usenet/Contexts/ContextualCancellationTokenSource.cs
+++ b/backend/Clients/Usenet/Contexts/ContextualCancellationTokenSource.cs
@@ -21,6 +21,7 @@ public class ContextualCancellationTokenSource : IDisposable
         var cts = CancellationTokenSource.CreateLinkedTokenSource(linkedToken);
         var contextualCts = new ContextualCancellationTokenSource(cts);
         contextualCts.SetContext(linkedToken.GetContext<DownloadPriorityContext>());
+        contextualCts.SetContext(linkedToken.GetContext<StreamingTimeoutContext>());
         return contextualCts;
     }
 
@@ -34,6 +35,8 @@ public class ContextualCancellationTokenSource : IDisposable
         var contextualCts = new ContextualCancellationTokenSource(cts);
         contextualCts.SetContext(linkedToken1.GetContext<DownloadPriorityContext>());
         contextualCts.SetContext(linkedToken2.GetContext<DownloadPriorityContext>());
+        contextualCts.SetContext(linkedToken1.GetContext<StreamingTimeoutContext>());
+        contextualCts.SetContext(linkedToken2.GetContext<StreamingTimeoutContext>());
         return contextualCts;
     }
 

--- a/backend/Clients/Usenet/Contexts/StreamingTimeoutContext.cs
+++ b/backend/Clients/Usenet/Contexts/StreamingTimeoutContext.cs
@@ -1,0 +1,7 @@
+namespace NzbWebDAV.Clients.Usenet.Contexts;
+
+public record StreamingTimeoutContext
+{
+    public required TimeSpan PerAttemptTimeout { get; init; }
+    public required int MaxRetries { get; init; }
+}

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Connections;
+using NzbWebDAV.Clients.Usenet.Contexts;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
@@ -141,6 +142,10 @@ public class MultiConnectionNntpClient(ConnectionPool<INntpClient> connectionPoo
         int retryCount = 1
     ) where T : UsenetResponse
     {
+        var streamingTimeout = ct.GetContext<StreamingTimeoutContext>();
+        if (streamingTimeout != null)
+            retryCount = streamingTimeout.MaxRetries;
+
         while (retryCount >= 0)
         {
             ConnectionLock<INntpClient>? connectionLock = null;
@@ -173,7 +178,32 @@ public class MultiConnectionNntpClient(ConnectionPool<INntpClient> connectionPoo
             T? result;
             try
             {
-                result = await command(connectionLock.Connection, OnConnectionReadyAgain).ConfigureAwait(false);
+                if (streamingTimeout != null)
+                {
+                    using var attemptCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    attemptCts.CancelAfter(streamingTimeout.PerAttemptTimeout);
+                    result = await command(connectionLock.Connection, OnConnectionReadyAgain)
+                        .WaitAsync(attemptCts.Token).ConfigureAwait(false);
+                }
+                else
+                {
+                    result = await command(connectionLock.Connection, OnConnectionReadyAgain).ConfigureAwait(false);
+                }
+            }
+            catch (Exception e) when (streamingTimeout != null && e.IsCancellationException() && !ct.IsCancellationRequested)
+            {
+                LogException(() => connectionLock?.Replace());
+                LogException(() => connectionLock?.Dispose());
+                if (retryCount > 0)
+                {
+                    Log.Debug($"Streaming timeout executing nntp {name} command after {streamingTimeout.PerAttemptTimeout.TotalSeconds}s. Retrying with a new connection ({retryCount} left).");
+                    retryCount--;
+                    continue;
+                }
+
+                Log.Warning($"Streaming timeout executing nntp {name} command after {streamingTimeout.PerAttemptTimeout.TotalSeconds}s. No retries left.");
+                LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
+                throw new TimeoutException($"Timeout executing nntp {name} command after {streamingTimeout.MaxRetries + 1} attempts.");
             }
             catch (Exception e) when (e.IsCancellationException())
             {

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -154,6 +154,23 @@ public class ConfigManager
         return new SemaphorePriorityOdds() { HighPriorityOdds = numericalValue };
     }
 
+    public TimeSpan GetStreamingSegmentTimeout()
+    {
+        var seconds = int.Parse(
+            StringUtil.EmptyToNull(GetConfigValue("usenet.streaming-segment-timeout"))
+            ?? "8"
+        );
+        return TimeSpan.FromSeconds(seconds);
+    }
+
+    public int GetStreamingSegmentRetries()
+    {
+        return int.Parse(
+            StringUtil.EmptyToNull(GetConfigValue("usenet.streaming-segment-retries"))
+            ?? "3"
+        );
+    }
+
     public bool IsEnforceReadonlyWebdavEnabled()
     {
         var defaultValue = true;

--- a/backend/WebDav/Base/BaseStoreStreamFile.cs
+++ b/backend/WebDav/Base/BaseStoreStreamFile.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.AspNetCore.Http;
 using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Contexts;
+using NzbWebDAV.Config;
 using NzbWebDAV.Extensions;
 
 namespace NzbWebDAV.WebDav.Base;
 
-public abstract class BaseStoreStreamFile(HttpContext context) : BaseStoreReadonlyItem
+public abstract class BaseStoreStreamFile(HttpContext context, ConfigManager configManager) : BaseStoreReadonlyItem
 {
     protected abstract Task<Stream> GetStreamAsync(CancellationToken cancellationToken);
 
@@ -13,9 +14,18 @@ public abstract class BaseStoreStreamFile(HttpContext context) : BaseStoreReadon
     {
         var downloadPriorityContext = new DownloadPriorityContext() { Priority = SemaphorePriority.High };
         var scopedDownloadPriorityContext = cancellationToken.SetContext(downloadPriorityContext);
+
+        var streamingTimeoutContext = new StreamingTimeoutContext
+        {
+            PerAttemptTimeout = configManager.GetStreamingSegmentTimeout(),
+            MaxRetries = configManager.GetStreamingSegmentRetries()
+        };
+        var scopedStreamingTimeoutContext = cancellationToken.SetContext(streamingTimeoutContext);
+
         context.Response.OnCompleted(() =>
         {
             scopedDownloadPriorityContext.Dispose();
+            scopedStreamingTimeoutContext.Dispose();
             return Task.CompletedTask;
         });
 

--- a/backend/WebDav/DatabaseStoreMultipartFile.cs
+++ b/backend/WebDav/DatabaseStoreMultipartFile.cs
@@ -15,7 +15,7 @@ public class DatabaseStoreMultipartFile(
     DavDatabaseClient dbClient,
     UsenetStreamingClient usenetClient,
     ConfigManager configManager
-) : BaseStoreStreamFile(httpContext)
+) : BaseStoreStreamFile(httpContext, configManager)
 {
     public DavItem DavItem => davMultipartFile;
     public override string Name => davMultipartFile.Name;

--- a/backend/WebDav/DatabaseStoreNzbFile.cs
+++ b/backend/WebDav/DatabaseStoreNzbFile.cs
@@ -14,7 +14,7 @@ public class DatabaseStoreNzbFile(
     DavDatabaseClient dbClient,
     INntpClient usenetClient,
     ConfigManager configManager
-) : BaseStoreStreamFile(httpContext)
+) : BaseStoreStreamFile(httpContext, configManager)
 {
     public DavItem DavItem => davNzbFile;
     public override string Name => davNzbFile.Name;

--- a/backend/WebDav/DatabaseStoreRarFile.cs
+++ b/backend/WebDav/DatabaseStoreRarFile.cs
@@ -15,7 +15,7 @@ public class DatabaseStoreRarFile(
     DavDatabaseClient dbClient,
     UsenetStreamingClient usenetClient,
     ConfigManager configManager
-) : BaseStoreStreamFile(httpContext)
+) : BaseStoreStreamFile(httpContext, configManager)
 {
     public DavItem DavItem => davRarFile;
     public override string Name => davRarFile.Name;


### PR DESCRIPTION
## Reduce choppy streaming playback caused by NNTP segment timeouts

### Problem

During WebDAV streaming playback, if a Usenet provider stalls mid-transfer on a segment, UsenetSharp's internal read timeout takes ~40 seconds to fire. With only 1 retry (also subject to the same ~40s timeout), a single slow segment can stall the media player for up to ~80 seconds - causing visible choppiness or complete playback interruption.

The download/queue paths can tolerate this latency, but real-time streaming cannot.

### Solution

Introduce a **per-attempt timeout** and **increased retry count** specifically for WebDAV streaming requests, without affecting download/queue behavior.

When a file is streamed via WebDAV, a `StreamingTimeoutContext` is attached to the cancellation token (using the same context propagation pattern as the existing `DownloadPriorityContext`). Inside `MultiConnectionNntpClient.RunWithConnection`, if this context is present, each NNTP command attempt is wrapped with a tighter `CancelAfter` that fires well before UsenetSharp's internal timeout. If the per-attempt timeout fires but the caller's token is still alive, the stale connection is replaced and the command is retried immediately on a fresh connection.

**Before:** ~40s timeout × 2 attempts = ~80s worst-case stall per segment
**After:** ~8s timeout × 4 attempts = ~32s worst-case, with each retry getting a fresh connection

### Configuration

Two new settings (with sensible defaults):

| Setting | Default | Description |
|---------|---------|-------------|
| `usenet.streaming-segment-timeout` | `8` (seconds) | Per-attempt timeout for streaming segment fetches |
| `usenet.streaming-segment-retries` | `3` | Max retries per segment during streaming |

These only apply to WebDAV streaming paths. Download queue, health checks, and other non-streaming operations are unaffected.

### Changes

- **New:** `StreamingTimeoutContext` - carries timeout config through the cancellation token context
- **Modified:** `MultiConnectionNntpClient.RunWithConnection` - applies per-attempt timeout and streaming retry count when context is present
- **Modified:** `BaseStoreStreamFile` - sets `StreamingTimeoutContext` at the WebDAV streaming entry point
- **Modified:** `ContextualCancellationTokenSource` - propagates `StreamingTimeoutContext` through linked tokens
- **Modified:** `ConfigManager` - exposes the two new config settings
- **Modified:** `DatabaseStoreNzbFile`, `DatabaseStoreRarFile`, `DatabaseStoreMultipartFile`-  pass `ConfigManager` to base class

Fixes #383 