### PR TITLE
fix(api): log test-connection failures with provider context

### DIFF
--- a/backend/Api/Controllers/TestUsenetConnection/TestUsenetConnectionController.cs
+++ b/backend/Api/Controllers/TestUsenetConnection/TestUsenetConnectionController.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Exceptions;
+using NzbWebDAV.Extensions;
+using Serilog;
 
 namespace NzbWebDAV.Api.Controllers.TestUsenetConnection;
 
@@ -15,13 +17,25 @@ public class TestUsenetConnectionController() : BaseApiController
             await UsenetStreamingClient.CreateNewConnection(request.ToConnectionDetails(), HttpContext.RequestAborted).ConfigureAwait(false);
             return new TestUsenetConnectionResponse { Status = true, Connected = true };
         }
-        catch (CouldNotConnectToUsenetException)
+        catch (CouldNotConnectToUsenetException e)
         {
+            var inner = e.InnerException?.Message ?? e.Message;
+            Log.Warning("Test connection failed for {Host}:{Port} (ssl={UseSsl}, user={User}): connect error: {Error}",
+                request.Host, request.Port, request.UseSsl, request.User, inner);
             return new TestUsenetConnectionResponse { Status = true, Connected = false };
         }
-        catch (CouldNotLoginToUsenetException)
+        catch (CouldNotLoginToUsenetException e)
         {
+            var inner = e.InnerException?.Message ?? e.Message;
+            Log.Warning("Test connection failed for {Host}:{Port} (ssl={UseSsl}, user={User}): login error: {Error}",
+                request.Host, request.Port, request.UseSsl, request.User, inner);
             return new TestUsenetConnectionResponse { Status = true, Connected = false };
+        }
+        catch (Exception e) when (!e.IsCancellationException())
+        {
+            Log.Warning(e, "Test connection failed for {Host}:{Port} (ssl={UseSsl}, user={User}): unexpected error",
+                request.Host, request.Port, request.UseSsl, request.User);
+            throw;
         }
     }
 


### PR DESCRIPTION
## Summary

The `/api/test-usenet-connection` endpoint silently swallows `CouldNotConnectToUsenetException` and `CouldNotLoginToUsenetException` and returns `connected: false` with **no log line**. Users hitting "Connection test failed" in the UI have no way to diagnose the actual cause — bad credentials, DNS failure, TLS handshake failure, server-side rejection, unreachable host, etc. — without attaching a debugger or packet-sniffing.

I hit this debugging a real provider misconfiguration this week: the UI showed the generic red banner and the pod logs were silent. The fix took five minutes once I knew the error message; finding the message took much longer.

## Changes

`backend/Api/Controllers/TestUsenetConnection/TestUsenetConnectionController.cs`:

- Add `Log.Warning` to the `CouldNotConnectToUsenetException` catch — prefixed `connect error`.
- Add `Log.Warning` to the `CouldNotLoginToUsenetException` catch — prefixed `login error`.
- Add a catch for unexpected non-cancellation exceptions that logs with stack trace, then **rethrows** so `BaseApiController`'s existing 500 handler still runs (preserves the frontend's `"Failed to test connection"` branch for non-NNTP failures).

Each log line includes host, port, SSL flag, user, and the inner exception message:

```
Test connection failed for news.example.com:563 (ssl=True, user=alice): login error: 481 Authentication failed
Test connection failed for news.example.com:563 (ssl=True, user=alice): connect error: The remote certificate is invalid according to the validation procedure
```

The wire-format response is unchanged — `connected: false` still goes back on the typed exceptions. This is purely additive observability.

## Test plan

- [x] `dotnet build` clean (0 errors, 77 pre-existing warnings)
- [ ] Manual: test connection with deliberately wrong password → log line with `login error: 481 ...`
- [ ] Manual: test connection with unreachable host → log line with `connect error: ...`
- [ ] Manual: test connection with valid credentials → no warning, `connected: true` returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)