### PR TITLE
feat(frontend): add dashboard page

### DIFF
--- a/frontend/app/routes/_index/components/left-navigation/left-navigation.module.css
+++ b/frontend/app/routes/_index/components/left-navigation/left-navigation.module.css
@@ -41,6 +41,15 @@
     user-select: none;
 }
 
+.dashboard-icon {
+    display: inline-block;
+    width: 22px;
+    height: 22px;
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%2393a1a1' d='M3 13h8V3H3zm0 8h8v-6H3zm10 0h8V11h-8zm0-18v6h8V3z'/%3E%3C/svg%3E");
+}
+
 .queue-icon {
     display: inline-block;
     width: 22px;

--- a/frontend/app/routes/_index/components/left-navigation/left-navigation.module.css.d.ts
+++ b/frontend/app/routes/_index/components/left-navigation/left-navigation.module.css.d.ts
@@ -1,5 +1,6 @@
 declare const styles: {
   readonly "container": string;
+  readonly "dashboard-icon": string;
   readonly "explore-icon": string;
   readonly "footer": string;
   readonly "footer-item": string;

--- a/frontend/app/routes/_index/components/left-navigation/left-navigation.tsx
+++ b/frontend/app/routes/_index/components/left-navigation/left-navigation.tsx
@@ -12,6 +12,10 @@ export type LeftNavigationProps = {
 export function LeftNavigation({ version, isFrontendAuthDisabled }: LeftNavigationProps) {
     return (
         <div className={styles.container}>
+            <Item target="/dashboard">
+                <div className={styles["dashboard-icon"]} />
+                <div className={styles.title}>Dashboard</div>
+            </Item>
             <Item target="/queue">
                 <div className={styles["queue-icon"]} />
                 <div className={styles.title}>Queue & History</div>

--- a/frontend/app/routes/_index/route.tsx
+++ b/frontend/app/routes/_index/route.tsx
@@ -2,5 +2,5 @@ import { redirect } from "react-router";
 import type { Route } from "./+types/route";
 
 export async function loader({ request }: Route.LoaderArgs) {
-    return redirect("/queue")
+    return redirect("/dashboard")
 }

--- a/frontend/app/routes/dashboard/components/connection-activity/connection-activity.module.css
+++ b/frontend/app/routes/dashboard/components/connection-activity/connection-activity.module.css
@@ -1,0 +1,80 @@
+.container {
+    width: 100%;
+    background: hsl(196.8 80% 7%);
+    border-radius: 10px;
+    padding: 24px;
+    border: 1px solid rgba(255, 255, 255, 0.03);
+}
+
+.title {
+    margin: 0 0 20px 0;
+}
+
+.empty {
+    color: hsl(180, 7%, 55%);
+}
+
+.providers {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.provider {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.providerHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+}
+
+.host {
+    font-weight: 500;
+    word-break: break-all;
+}
+
+.badge {
+    font-size: 0.75em;
+    color: hsl(180, 7%, 55%);
+    background: hsl(196.8, 25%, 14.51%);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: 12px;
+    padding: 2px 8px;
+    white-space: nowrap;
+}
+
+.bar {
+    position: relative;
+    height: 10px;
+    border-radius: 5px;
+    overflow: hidden;
+    background: hsl(196.8, 25%, 14.51%);
+}
+
+.barLive {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background: hsl(192, 80%, 35%);
+    transition: width 0.3s ease;
+}
+
+.barActive {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background: hsl(140, 60%, 45%);
+    transition: width 0.3s ease;
+}
+
+.caption {
+    font-size: 0.85em;
+    color: hsl(180, 7%, 55%);
+}

--- a/frontend/app/routes/dashboard/components/connection-activity/connection-activity.module.css.d.ts
+++ b/frontend/app/routes/dashboard/components/connection-activity/connection-activity.module.css.d.ts
@@ -1,0 +1,15 @@
+declare const styles: {
+  readonly "container": string;
+  readonly "title": string;
+  readonly "empty": string;
+  readonly "providers": string;
+  readonly "provider": string;
+  readonly "providerHeader": string;
+  readonly "host": string;
+  readonly "badge": string;
+  readonly "bar": string;
+  readonly "barLive": string;
+  readonly "barActive": string;
+  readonly "caption": string;
+};
+export = styles;

--- a/frontend/app/routes/dashboard/components/connection-activity/connection-activity.tsx
+++ b/frontend/app/routes/dashboard/components/connection-activity/connection-activity.tsx
@@ -1,0 +1,72 @@
+import styles from "./connection-activity.module.css";
+import type { ConnectionState, DashboardProvider } from "../../route";
+
+export type ConnectionActivityProps = {
+    providers: DashboardProvider[],
+    connections: ConnectionState,
+};
+
+// Mirrors backend NzbWebDAV.Models.ProviderType
+const ProviderType = {
+    Pooled: 1,
+    BackupAndStats: 2,
+    BackupOnly: 3,
+} as const;
+
+function providerTypeLabel(type: number): string {
+    if (type === ProviderType.BackupAndStats) return "Backup";
+    if (type === ProviderType.BackupOnly) return "Backup";
+    return "Primary";
+}
+
+export function ConnectionActivity({ providers, connections }: ConnectionActivityProps) {
+    return (
+        <div className={styles.container}>
+            <h3 className={styles.title}>Usenet Connections</h3>
+            {providers.length === 0 && (
+                <div className={styles.empty}>
+                    No usenet providers configured.
+                </div>
+            )}
+            <div className={styles.providers}>
+                {providers.map(provider => (
+                    <ProviderRow
+                        key={provider.index}
+                        provider={provider}
+                        connection={connections[provider.index]}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+type ProviderRowProps = {
+    provider: DashboardProvider,
+    connection: { live: number, idle: number } | undefined,
+};
+
+function ProviderRow({ provider, connection }: ProviderRowProps) {
+    const live = connection?.live ?? 0;
+    const idle = connection?.idle ?? 0;
+    const active = Math.max(0, live - idle);
+    const max = Math.max(1, provider.maxConnections);
+    const livePercent = Math.min(100, (live / max) * 100);
+    const activePercent = Math.min(100, (active / max) * 100);
+
+    return (
+        <div className={styles.provider}>
+            <div className={styles.providerHeader}>
+                <span className={styles.host}>{provider.host}</span>
+                <span className={styles.badge}>{providerTypeLabel(provider.type)}</span>
+            </div>
+            <div className={styles.bar}>
+                <div className={styles.barLive} style={{ width: `${livePercent}%` }} />
+                <div className={styles.barActive} style={{ width: `${activePercent}%` }} />
+            </div>
+            <div className={styles.caption}>
+                {active} active &middot; {live} connected &middot; {provider.maxConnections} max
+            </div>
+        </div>
+    );
+}

--- a/frontend/app/routes/dashboard/components/queue-activity/queue-activity.module.css
+++ b/frontend/app/routes/dashboard/components/queue-activity/queue-activity.module.css
@@ -1,0 +1,88 @@
+.container {
+    width: 100%;
+    background: hsl(196.8 80% 7%);
+    border-radius: 10px;
+    padding: 24px;
+    border: 1px solid rgba(255, 255, 255, 0.03);
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+    gap: 12px;
+}
+
+.title {
+    margin: 0;
+}
+
+.count {
+    color: hsl(180, 7%, 55%);
+    font-size: 0.9em;
+    font-weight: 500;
+    background: hsl(196.8, 25%, 14.51%);
+    padding: 6px 12px;
+    border-radius: 16px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    white-space: nowrap;
+}
+
+.empty {
+    color: hsl(180, 7%, 55%);
+}
+
+.items {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.item {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.itemHeader {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: baseline;
+}
+
+.filename {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.status {
+    font-size: 0.8em;
+    color: hsl(180, 7%, 55%);
+    white-space: nowrap;
+}
+
+.bar {
+    position: relative;
+    height: 8px;
+    border-radius: 4px;
+    overflow: hidden;
+    background: hsl(196.8, 25%, 14.51%);
+}
+
+.barFill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background: hsl(192, 80%, 40%);
+    transition: width 0.3s ease;
+}
+
+.more {
+    margin-top: 14px;
+    font-size: 0.85em;
+    color: hsl(180, 7%, 55%);
+}

--- a/frontend/app/routes/dashboard/components/queue-activity/queue-activity.module.css.d.ts
+++ b/frontend/app/routes/dashboard/components/queue-activity/queue-activity.module.css.d.ts
@@ -1,0 +1,16 @@
+declare const styles: {
+  readonly "container": string;
+  readonly "header": string;
+  readonly "title": string;
+  readonly "count": string;
+  readonly "empty": string;
+  readonly "items": string;
+  readonly "item": string;
+  readonly "itemHeader": string;
+  readonly "filename": string;
+  readonly "status": string;
+  readonly "bar": string;
+  readonly "barFill": string;
+  readonly "more": string;
+};
+export = styles;

--- a/frontend/app/routes/dashboard/components/queue-activity/queue-activity.tsx
+++ b/frontend/app/routes/dashboard/components/queue-activity/queue-activity.tsx
@@ -1,0 +1,57 @@
+import styles from "./queue-activity.module.css";
+import type { QueueSlot } from "~/clients/backend-client.server";
+
+export type QueueActivityProps = {
+    slots: QueueSlot[],
+};
+
+const maxVisibleItems = 5;
+
+function clampPercent(value: string): number {
+    const parsed = Number(value);
+    if (Number.isNaN(parsed)) return 0;
+    return Math.min(100, Math.max(0, parsed));
+}
+
+export function QueueActivity({ slots }: QueueActivityProps) {
+    const visible = slots.slice(0, maxVisibleItems);
+    const overflow = slots.length - visible.length;
+
+    return (
+        <div className={styles.container}>
+            <div className={styles.header}>
+                <h3 className={styles.title}>Queue</h3>
+                <span className={styles.count}>
+                    {slots.length} {slots.length === 1 ? "item" : "items"}
+                </span>
+            </div>
+            {slots.length === 0 && (
+                <div className={styles.empty}>Queue is idle.</div>
+            )}
+            <div className={styles.items}>
+                {visible.map(slot => {
+                    const percent = clampPercent(slot.true_percentage);
+                    return (
+                        <div key={slot.nzo_id} className={styles.item}>
+                            <div className={styles.itemHeader}>
+                                <span className={styles.filename}>{slot.filename}</span>
+                                <span className={styles.status}>{slot.status}</span>
+                            </div>
+                            <div className={styles.bar}>
+                                <div
+                                    className={styles.barFill}
+                                    style={{ width: `${percent}%` }}
+                                />
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+            {overflow > 0 && (
+                <div className={styles.more}>
+                    + {overflow} more in queue
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/app/routes/dashboard/route.module.css
+++ b/frontend/app/routes/dashboard/route.module.css
@@ -1,0 +1,14 @@
+.container {
+    padding: 20px;
+    width: 100%;
+}
+
+.heading {
+    margin: 0 0 20px 0;
+}
+
+.stack {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}

--- a/frontend/app/routes/dashboard/route.module.css.d.ts
+++ b/frontend/app/routes/dashboard/route.module.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles: {
+  readonly "container": string;
+  readonly "heading": string;
+  readonly "stack": string;
+};
+export = styles;

--- a/frontend/app/routes/dashboard/route.tsx
+++ b/frontend/app/routes/dashboard/route.tsx
@@ -1,0 +1,138 @@
+import type { Route } from "./+types/route";
+import styles from "./route.module.css";
+import { backendClient } from "~/clients/backend-client.server";
+import { HealthStats } from "~/routes/health/components/health-stats/health-stats";
+import { ConnectionActivity } from "./components/connection-activity/connection-activity";
+import { QueueActivity } from "./components/queue-activity/queue-activity";
+import { useCallback, useEffect, useState } from "react";
+import { receiveMessage } from "~/utils/websocket-util";
+import { useNavigate } from "react-router";
+import type { QueueSlot } from "~/clients/backend-client.server";
+
+// Provider roster shape exposed to the browser. Usenet credentials
+// (User/Pass) are intentionally stripped server-side in the loader and
+// never reach the client bundle.
+export type DashboardProvider = {
+    index: number,
+    host: string,
+    type: number,
+    maxConnections: number,
+};
+
+// Mirrors backend NzbWebDAV.Models.ProviderType
+const ProviderType = {
+    Disabled: 0,
+    Pooled: 1,
+    BackupAndStats: 2,
+    BackupOnly: 3,
+} as const;
+
+// Per-provider live connection counts, keyed by provider index.
+export type ConnectionState = Record<number, { live: number, idle: number }>;
+
+const topicSubscriptions = {
+    cxs: 'state',  // usenet connections
+    qs: 'state',   // queue item status
+    qp: 'state',   // queue item progress
+    qa: 'event',   // queue item added
+    qr: 'event',   // queue item removed
+};
+
+function parseProviders(configValue: string | undefined): DashboardProvider[] {
+    if (!configValue) return [];
+    try {
+        const parsed = JSON.parse(configValue) as {
+            Providers?: Array<{ Host?: string, Type?: number, MaxConnections?: number }>
+        };
+        return (parsed.Providers ?? [])
+            .map((provider, index) => ({
+                index,
+                host: provider.Host || `provider ${index + 1}`,
+                type: provider.Type ?? ProviderType.Disabled,
+                maxConnections: provider.MaxConnections ?? 0,
+            }))
+            .filter(provider => provider.type !== ProviderType.Disabled);
+    } catch {
+        return [];
+    }
+}
+
+export async function loader() {
+    const [historyData, queueData, config] = await Promise.all([
+        backendClient.getHealthCheckHistory(),
+        backendClient.getQueue(100),
+        backendClient.getConfig(["usenet.providers"]),
+    ]);
+
+    const providersValue = config
+        .find(x => x.configName === "usenet.providers")
+        ?.configValue;
+
+    return {
+        historyStats: historyData.stats,
+        queueSlots: queueData?.slots ?? [],
+        // Credentials are dropped here — only host/type/limits cross the wire.
+        providers: parseProviders(providersValue),
+    };
+}
+
+export default function Dashboard({ loaderData }: Route.ComponentProps) {
+    const navigate = useNavigate();
+    const { historyStats, providers } = loaderData;
+
+    const [queueSlots, setQueueSlots] = useState<QueueSlot[]>(loaderData.queueSlots);
+    const [connections, setConnections] = useState<ConnectionState>({});
+
+    const onWebsocketMessage = useCallback((topic: string, message: string) => {
+        if (topic === 'cxs') {
+            // providerIndex|live|idle|totalLive|max|totalIdle
+            const [providerIndex, live, idle] = message.split('|').map(Number);
+            if (Number.isNaN(providerIndex)) return;
+            setConnections(prev => ({ ...prev, [providerIndex]: { live, idle } }));
+        } else if (topic === 'qs') {
+            const [nzoId, status] = message.split('|');
+            setQueueSlots(prev => prev.map(slot =>
+                slot.nzo_id === nzoId ? { ...slot, status } : slot));
+        } else if (topic === 'qp') {
+            const [nzoId, truePercentage] = message.split('|');
+            setQueueSlots(prev => prev.map(slot =>
+                slot.nzo_id === nzoId ? { ...slot, true_percentage: truePercentage } : slot));
+        } else if (topic === 'qa') {
+            const slot = JSON.parse(message) as QueueSlot;
+            setQueueSlots(prev => prev.some(x => x.nzo_id === slot.nzo_id)
+                ? prev
+                : [...prev, slot]);
+        } else if (topic === 'qr') {
+            const removed = new Set(message.split(','));
+            setQueueSlots(prev => prev.filter(slot => !removed.has(slot.nzo_id)));
+        }
+    }, []);
+
+    useEffect(() => {
+        let ws: WebSocket;
+        let disposed = false;
+        function connect() {
+            ws = new WebSocket(window.location.origin.replace(/^http/, 'ws'));
+            ws.onmessage = receiveMessage(onWebsocketMessage);
+            ws.onopen = () => ws.send(JSON.stringify(topicSubscriptions));
+            ws.onerror = () => ws.close();
+            ws.onclose = (e: CloseEvent) => {
+                if (e.code === 1008) navigate('/login');
+                else if (!disposed) setTimeout(connect, 1000);
+            };
+            return () => { disposed = true; ws.close(); };
+        }
+        return connect();
+    }, [onWebsocketMessage, navigate]);
+
+    return (
+        <div className={styles.container}>
+            <h2 className={styles.heading}>Dashboard</h2>
+            <div className={styles.stack}>
+                <ConnectionActivity providers={providers} connections={connections} />
+                <QueueActivity slots={queueSlots} />
+                <HealthStats stats={historyStats} />
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
Adds a new "Dashboard" navigation section that serves as the default landing page when accessing the GUI.

The dashboard surfaces high-level live information using data and WebSocket topics that already exist in the backend, so no backend changes are required:

- Usenet connection activity, broken down per provider, fed by the existing "cxs" WebSocket topic.
- Queue-at-a-glance, showing in-flight items and progress, fed by the existing "qs"/"qp"/"qa"/"qr" topics.
- Health summary, reusing the existing HealthStats component from the health page.

The "/" index route now redirects to "/dashboard" instead of "/queue".

Usenet provider credentials are stripped server-side in the loader; only host, type and connection limits are sent to the browser.