### PR TITLE
fix(api): Treat history delete as idempotent when row is already gone

### DIFF
--- a/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryController.cs
+++ b/backend/Api/SabControllers/RemoveFromHistory/RemoveFromHistoryController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Config;
 using NzbWebDAV.Database;
 using NzbWebDAV.Websocket;
@@ -16,7 +17,14 @@ public class RemoveFromHistoryController(
     public async Task<RemoveFromHistoryResponse> RemoveFromHistory(RemoveFromHistoryRequest request)
     {
         await dbClient.RemoveHistoryItemsAsync(request.NzoIds, request.DeleteCompletedFiles, request.CancellationToken).ConfigureAwait(false);
-        await dbClient.Ctx.SaveChangesAsync(request.CancellationToken).ConfigureAwait(false);
+        try
+        {
+            await dbClient.Ctx.SaveChangesAsync(request.CancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            // Item already removed by a prior call; SAB API delete is idempotent.
+        }
         _ = websocketManager.SendMessage(WebsocketTopic.HistoryItemRemoved, string.Join(",", request.NzoIds));
         return new RemoveFromHistoryResponse() { Status = true };
     }


### PR DESCRIPTION
A Radarr/Sonarr instance pointed at nzbdav can get stuck in a tight retry loop against the `mode=history&name=delete` endpoint, driving nzbdav CPU to 100%+ on a single core indefinitely. The only recovery is restarting the arr container.

The loop happens because nzbdav returns HTTP 500 when asked to delete an nzo_id that's already gone from HistoryItems. The arr treats 500 as a transient failure and re-fires the same delete every ~90s forever, since the nzo_id lives in its in-memory TrackedDownloads cache and never gets evicted.

Real SABnzbd treats `name=delete` as idempotent: if the record is already gone, that's still a success. This PR matches that behavior. When the delete finds nothing to remove, return the standard success response instead of bubbling a database error up as a 500.
