### PR TITLE
fix(streams): cap prefetch at requested HTTP Range end

### DIFF
--- a/backend/Clients/Usenet/INntpClient.cs
+++ b/backend/Clients/Usenet/INntpClient.cs
@@ -59,7 +59,7 @@ public interface INntpClient : IDisposable
         NzbFile nzbFile, long fileSize, int articleBufferSize);
 
     NzbFileStream GetFileStream(
-        string[] segmentIds, long fileSize, int articleBufferSize);
+        string[] segmentIds, long fileSize, int articleBufferSize, long? requestedEndByte = null);
 
     Task CheckAllSegmentsAsync(
         IEnumerable<string> segmentIds, int concurrency, IProgress<int>? progress, CancellationToken cancellationToken);

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -100,9 +100,10 @@ public abstract class NntpClient : INntpClient
         return new NzbFileStream(nzbFile.GetSegmentIds(), fileSize, this, articleBufferSize);
     }
 
-    public virtual NzbFileStream GetFileStream(string[] segmentIds, long fileSize, int articleBufferSize)
+    public virtual NzbFileStream GetFileStream(
+        string[] segmentIds, long fileSize, int articleBufferSize, long? requestedEndByte = null)
     {
-        return new NzbFileStream(segmentIds, fileSize, this, articleBufferSize);
+        return new NzbFileStream(segmentIds, fileSize, this, articleBufferSize, requestedEndByte);
     }
 
     public virtual async Task CheckAllSegmentsAsync

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -13,6 +13,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     private readonly INntpClient _usenetClient;
     private readonly Channel<Task<Stream>> _streamTasks;
     private readonly ContextualCancellationTokenSource _cts;
+    private readonly int? _endSegmentCount;
     private Stream? _stream;
     private bool _disposed;
 
@@ -21,12 +22,13 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         Memory<string> segmentIds,
         INntpClient usenetClient,
         int articleBufferSize,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        int? endSegmentCount = null
     )
     {
         return articleBufferSize == 0
             ? new UnbufferedMultiSegmentStream(segmentIds, usenetClient)
-            : new MultiSegmentStream(segmentIds, usenetClient, articleBufferSize, cancellationToken);
+            : new MultiSegmentStream(segmentIds, usenetClient, articleBufferSize, cancellationToken, endSegmentCount);
     }
 
     private MultiSegmentStream
@@ -34,21 +36,26 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         Memory<string> segmentIds,
         INntpClient usenetClient,
         int articleBufferSize,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        int? endSegmentCount = null
     )
     {
         _segmentIds = segmentIds;
         _usenetClient = usenetClient;
         _streamTasks = Channel.CreateBounded<Task<Stream>>(articleBufferSize);
         _cts = ContextualCancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _endSegmentCount = endSegmentCount;
         _ = DownloadSegments(_cts.Token);
     }
 
     private async Task DownloadSegments(CancellationToken cancellationToken)
     {
+        var effectiveCount = _endSegmentCount.HasValue
+            ? Math.Min(_segmentIds.Length, _endSegmentCount.Value)
+            : _segmentIds.Length;
         try
         {
-            for (var i = 0; i < _segmentIds.Length; i++)
+            for (var i = 0; i < effectiveCount; i++)
             {
                 var segmentId = _segmentIds.Span[i];
 

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -2,6 +2,7 @@
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Utils;
+using Serilog;
 using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Streams;
@@ -10,9 +11,13 @@ public class NzbFileStream(
     string[] fileSegmentIds,
     long fileSize,
     INntpClient usenetClient,
-    int articleBufferSize
+    int articleBufferSize,
+    long? requestedEndByte = null
 ) : FastReadOnlyStream
 {
+    // Extra segments fetched past the requested end to cover seek imprecision.
+    private const int RangePrefetchOvershootSegments = 4;
+
     private long _position;
     private bool _disposed;
     private Stream? _innerStream;
@@ -80,7 +85,35 @@ public class NzbFileStream(
     private Stream GetMultiSegmentStream(int firstSegmentIndex, CancellationToken cancellationToken)
     {
         var segmentIds = fileSegmentIds.AsMemory()[firstSegmentIndex..];
-        return MultiSegmentStream.Create(segmentIds, usenetClient, articleBufferSize, cancellationToken);
+        var endSegmentCount = ComputeEndSegmentCount(firstSegmentIndex, segmentIds.Length);
+        if (endSegmentCount.HasValue)
+        {
+            Log.Debug(
+                "Range-bounded prefetch: requestedEndByte={EndByte}, firstSegmentIndex={First}, "
+                + "endSegmentCount={Count} (of {Remaining} remaining segments)",
+                requestedEndByte, firstSegmentIndex, endSegmentCount.Value, segmentIds.Length);
+        }
+        return MultiSegmentStream.Create(
+            segmentIds, usenetClient, articleBufferSize, cancellationToken, endSegmentCount);
+    }
+
+    // Returns segment count covering requestedEndByte, or null when no cap is needed.
+    private int? ComputeEndSegmentCount(int firstSegmentIndex, int remainingSegmentCount)
+    {
+        if (!requestedEndByte.HasValue) return null;
+        if (fileSegmentIds.Length == 0 || remainingSegmentCount <= 0) return null;
+
+        var endByte = Math.Clamp(requestedEndByte.Value, 0, fileSize - 1);
+        var avgSegmentSize = (double)fileSize / fileSegmentIds.Length;
+        if (avgSegmentSize <= 0) return null;
+
+        var absoluteEndIndex = Math.Clamp(
+            (int)(endByte / avgSegmentSize), 0, fileSegmentIds.Length - 1);
+        var withOvershoot = absoluteEndIndex + RangePrefetchOvershootSegments;
+        var relativeCount = withOvershoot - firstSegmentIndex + 1;
+        if (relativeCount <= 0) return 0;
+        if (relativeCount >= remainingSegmentCount) return null;
+        return relativeCount;
     }
 
     protected override void Dispose(bool disposing)

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -48,6 +48,10 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         // Determine the requested range
         var range = request.GetRange();
 
+        // Forward closed-range end byte to downstream prefetch capping.
+        if (range?.End is long requestedRangeEnd)
+            httpContext.Items["RequestedRangeEnd"] = requestedRangeEnd;
+
         // Obtain the WebDAV collection
         var entry = await _store.GetItemAsync(request.GetUri(), httpContext.RequestAborted).ConfigureAwait(false);
         if (entry == null)

--- a/backend/WebDav/DatabaseStoreNzbFile.cs
+++ b/backend/WebDav/DatabaseStoreNzbFile.cs
@@ -36,6 +36,9 @@ public class DatabaseStoreNzbFile(
 
     private NzbFileStream GetStream(DavNzbFile nzbFile)
     {
-        return usenetClient.GetFileStream(nzbFile.SegmentIds, FileSize, configManager.GetArticleBufferSize());
+        // Closed-range end byte from GetAndHeadHandlerPatch, used to cap prefetch.
+        var requestedEndByte = httpContext.Items["RequestedRangeEnd"] as long?;
+        return usenetClient.GetFileStream(
+            nzbFile.SegmentIds, FileSize, configManager.GetArticleBufferSize(), requestedEndByte);
     }
 }


### PR DESCRIPTION
The default usenet.article-buffer-size=80 means nzbdav always grabs ~56 MB ahead from Usenet whenever it opens a file, even when the caller only asked for a tiny slice. That's fine for streaming playback but it's huge waste for small requests like ffprobe scans on radarr import or Plex's Background Media Analyzer (which can't be disabled) probing container headers, where the caller just takes a few KB and closes the connection, especially for large libraries. The change reads the HTTP Range end from the request and only prefetches enough articles to cover what was actually asked for (plus a tiny bit extra).