### PR TITLE
fix(nntp): add configurable connection idle timeout + cap prefetch at HTTP Range end

### DIFF
--- a/backend/Clients/Usenet/INntpClient.cs
+++ b/backend/Clients/Usenet/INntpClient.cs
@@ -59,7 +59,7 @@ public interface INntpClient : IDisposable
         NzbFile nzbFile, long fileSize, int articleBufferSize);
 
     NzbFileStream GetFileStream(
-        string[] segmentIds, long fileSize, int articleBufferSize);
+        string[] segmentIds, long fileSize, int articleBufferSize, long? requestedEndByte = null);
 
     Task CheckAllSegmentsAsync(
         IEnumerable<string> segmentIds, int concurrency, IProgress<int>? progress, CancellationToken cancellationToken);

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -100,9 +100,10 @@ public abstract class NntpClient : INntpClient
         return new NzbFileStream(nzbFile.GetSegmentIds(), fileSize, this, articleBufferSize);
     }
 
-    public virtual NzbFileStream GetFileStream(string[] segmentIds, long fileSize, int articleBufferSize)
+    public virtual NzbFileStream GetFileStream(
+        string[] segmentIds, long fileSize, int articleBufferSize, long? requestedEndByte = null)
     {
-        return new NzbFileStream(segmentIds, fileSize, this, articleBufferSize);
+        return new NzbFileStream(segmentIds, fileSize, this, articleBufferSize, requestedEndByte);
     }
 
     public virtual async Task CheckAllSegmentsAsync

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -39,10 +39,12 @@ public class UsenetStreamingClient : WrappingNntpClient
     {
         var providerConfig = configManager.GetUsenetProviderConfig();
         var connectionPoolStats = new ConnectionPoolStats(providerConfig, websocketManager);
+        var idleTimeout = TimeSpan.FromSeconds(configManager.GetConnectionIdleTimeoutSeconds());
         var providerClients = providerConfig.Providers
             .Select((provider, index) => CreateProviderClient(
                 provider,
-                connectionPoolStats.GetOnConnectionPoolChanged(index)
+                connectionPoolStats.GetOnConnectionPoolChanged(index),
+                idleTimeout
             ))
             .ToList();
         return new MultiProviderNntpClient(providerClients);
@@ -51,13 +53,15 @@ public class UsenetStreamingClient : WrappingNntpClient
     private static MultiConnectionNntpClient CreateProviderClient
     (
         UsenetProviderConfig.ConnectionDetails connectionDetails,
-        EventHandler<ConnectionPoolStats.ConnectionPoolChangedEventArgs> onConnectionPoolChanged
+        EventHandler<ConnectionPoolStats.ConnectionPoolChangedEventArgs> onConnectionPoolChanged,
+        TimeSpan idleTimeout
     )
     {
         var connectionPool = CreateNewConnectionPool(
             maxConnections: connectionDetails.MaxConnections,
             connectionFactory: ct => CreateNewConnection(connectionDetails, ct),
-            onConnectionPoolChanged
+            onConnectionPoolChanged,
+            idleTimeout
         );
         var circuitBreaker = new ProviderCircuitBreaker(connectionDetails.Host);
         return new MultiConnectionNntpClient(connectionPool, connectionDetails.Type, circuitBreaker);
@@ -67,10 +71,11 @@ public class UsenetStreamingClient : WrappingNntpClient
     (
         int maxConnections,
         Func<CancellationToken, ValueTask<INntpClient>> connectionFactory,
-        EventHandler<ConnectionPoolStats.ConnectionPoolChangedEventArgs> onConnectionPoolChanged
+        EventHandler<ConnectionPoolStats.ConnectionPoolChangedEventArgs> onConnectionPoolChanged,
+        TimeSpan idleTimeout
     )
     {
-        var connectionPool = new ConnectionPool<INntpClient>(maxConnections, connectionFactory);
+        var connectionPool = new ConnectionPool<INntpClient>(maxConnections, connectionFactory, idleTimeout);
         connectionPool.OnConnectionPoolChanged += onConnectionPoolChanged;
         var args = new ConnectionPoolStats.ConnectionPoolChangedEventArgs(0, 0, maxConnections);
         onConnectionPoolChanged(connectionPool, args);

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -154,6 +154,14 @@ public class ConfigManager
         return new SemaphorePriorityOdds() { HighPriorityOdds = numericalValue };
     }
 
+    public int GetConnectionIdleTimeoutSeconds()
+    {
+        return int.Parse(
+            StringUtil.EmptyToNull(GetConfigValue("usenet.connection-idle-timeout-seconds"))
+            ?? "300"
+        );
+    }
+
     public bool IsEnforceReadonlyWebdavEnabled()
     {
         var defaultValue = true;

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -158,7 +158,7 @@ public class ConfigManager
     {
         return int.Parse(
             StringUtil.EmptyToNull(GetConfigValue("usenet.connection-idle-timeout-seconds"))
-            ?? "300"
+            ?? "120"
         );
     }
 

--- a/backend/Streams/DavMultipartFileStream.cs
+++ b/backend/Streams/DavMultipartFileStream.cs
@@ -8,7 +8,8 @@ namespace NzbWebDAV.Streams;
 public class DavMultipartFileStream(
     DavMultipartFile.FilePart[] fileParts,
     INntpClient usenetClient,
-    int articleBufferSize
+    int articleBufferSize,
+    long? requestedEndByte = null
 ) : Stream
 {
     private long _position = 0;
@@ -85,23 +86,56 @@ public class DavMultipartFileStream(
 
     private CombinedStream GetFileStream(long rangeStart)
     {
-        if (rangeStart == 0) return GetCombinedStream(0, 0);
+        if (rangeStart == 0)
+        {
+            return GetCombinedStream(0, 0, 0);
+        }
+
         var (filePartIndex, filePartOffset) = SeekFilePart(rangeStart);
-        var stream = GetCombinedStream(filePartIndex, rangeStart - filePartOffset);
-        return stream;
+        return GetCombinedStream(filePartIndex, rangeStart - filePartOffset, filePartOffset);
     }
 
-    private CombinedStream GetCombinedStream(int firstFilePartIndex, long additionalOffset)
+    private CombinedStream GetCombinedStream(int firstFilePartIndex, long additionalOffset, long firstPartFileStart)
     {
-        var streams = fileParts[firstFilePartIndex..]
+        var parts = fileParts[firstFilePartIndex..];
+
+        // File-absolute start of each part in the slice, for translating requestedEndByte per part.
+        var partFileStarts = new long[parts.Length];
+        var running = firstPartFileStart;
+        for (var i = 0; i < parts.Length; i++)
+        {
+            partFileStarts[i] = running;
+            running += parts[i].FilePartByteRange.Count;
+        }
+
+        var streams = parts
             .Select((x, i) =>
             {
                 var offset = (i == 0) ? additionalOffset : 0;
-                var stream = usenetClient.GetFileStream(x.SegmentIds, x.SegmentIdByteRange.Count, articleBufferSize);
+                var stream = usenetClient.GetFileStream(
+                    x.SegmentIds, x.SegmentIdByteRange.Count, articleBufferSize, GetPartEndByte(x, partFileStarts[i]));
                 stream.Seek(x.FilePartByteRange.StartInclusive + offset, SeekOrigin.Begin);
                 return Task.FromResult(stream.LimitLength(x.FilePartByteRange.Count - offset));
             });
         return new CombinedStream(streams);
+    }
+
+    // Translates the file-absolute requested end byte into this part's segment-data coordinate so the
+    // part's prefetch stops at the requested end. Null = no cap (the whole part is within the request).
+    private long? GetPartEndByte(DavMultipartFile.FilePart part, long partFileStart)
+    {
+        if (!requestedEndByte.HasValue)
+        {
+            return null;
+        }
+
+        var lastWantedByteInPart = requestedEndByte.Value - partFileStart;
+        if (lastWantedByteInPart < 0 || lastWantedByteInPart >= part.FilePartByteRange.Count - 1)
+        {
+            return null;
+        }
+
+        return part.FilePartByteRange.StartInclusive + lastWantedByteInPart;
     }
 
     protected override void Dispose(bool disposing)

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Channels;
+using System.Threading.Channels;
 using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Clients.Usenet.Contexts;
@@ -13,6 +13,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     private readonly INntpClient _usenetClient;
     private readonly Channel<Task<Stream>> _streamTasks;
     private readonly ContextualCancellationTokenSource _cts;
+    private readonly int? _endSegmentCount;
     private Stream? _stream;
     private bool _disposed;
 
@@ -21,12 +22,13 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         Memory<string> segmentIds,
         INntpClient usenetClient,
         int articleBufferSize,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        int? endSegmentCount = null
     )
     {
         return articleBufferSize == 0
             ? new UnbufferedMultiSegmentStream(segmentIds, usenetClient)
-            : new MultiSegmentStream(segmentIds, usenetClient, articleBufferSize, cancellationToken);
+            : new MultiSegmentStream(segmentIds, usenetClient, articleBufferSize, cancellationToken, endSegmentCount);
     }
 
     private MultiSegmentStream
@@ -34,21 +36,26 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
         Memory<string> segmentIds,
         INntpClient usenetClient,
         int articleBufferSize,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        int? endSegmentCount = null
     )
     {
         _segmentIds = segmentIds;
         _usenetClient = usenetClient;
         _streamTasks = Channel.CreateBounded<Task<Stream>>(articleBufferSize);
         _cts = ContextualCancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _endSegmentCount = endSegmentCount;
         _ = DownloadSegments(_cts.Token);
     }
 
     private async Task DownloadSegments(CancellationToken cancellationToken)
     {
+        var effectiveCount = _endSegmentCount.HasValue
+            ? Math.Min(_segmentIds.Length, _endSegmentCount.Value)
+            : _segmentIds.Length;
         try
         {
-            for (var i = 0; i < _segmentIds.Length; i++)
+            for (var i = 0; i < effectiveCount; i++)
             {
                 var segmentId = _segmentIds.Span[i];
 

--- a/backend/Streams/NzbFileStream.cs
+++ b/backend/Streams/NzbFileStream.cs
@@ -1,7 +1,8 @@
-﻿using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
 using NzbWebDAV.Utils;
+using Serilog;
 using UsenetSharp.Streams;
 
 namespace NzbWebDAV.Streams;
@@ -10,9 +11,13 @@ public class NzbFileStream(
     string[] fileSegmentIds,
     long fileSize,
     INntpClient usenetClient,
-    int articleBufferSize
+    int articleBufferSize,
+    long? requestedEndByte = null
 ) : FastReadOnlyStream
 {
+    // Extra segments fetched past the requested end to cover seek imprecision.
+    private const int RangePrefetchOvershootSegments = 4;
+
     private long _position;
     private bool _disposed;
     private Stream? _innerStream;
@@ -80,7 +85,35 @@ public class NzbFileStream(
     private Stream GetMultiSegmentStream(int firstSegmentIndex, CancellationToken cancellationToken)
     {
         var segmentIds = fileSegmentIds.AsMemory()[firstSegmentIndex..];
-        return MultiSegmentStream.Create(segmentIds, usenetClient, articleBufferSize, cancellationToken);
+        var endSegmentCount = ComputeEndSegmentCount(firstSegmentIndex, segmentIds.Length);
+        if (endSegmentCount.HasValue)
+        {
+            Log.Debug(
+                "Range-bounded prefetch: requestedEndByte={EndByte}, firstSegmentIndex={First}, "
+                + "endSegmentCount={Count} (of {Remaining} remaining segments)",
+                requestedEndByte, firstSegmentIndex, endSegmentCount.Value, segmentIds.Length);
+        }
+        return MultiSegmentStream.Create(
+            segmentIds, usenetClient, articleBufferSize, cancellationToken, endSegmentCount);
+    }
+
+    // Returns segment count covering requestedEndByte, or null when no cap is needed.
+    private int? ComputeEndSegmentCount(int firstSegmentIndex, int remainingSegmentCount)
+    {
+        if (!requestedEndByte.HasValue) return null;
+        if (fileSegmentIds.Length == 0 || remainingSegmentCount <= 0) return null;
+
+        var endByte = Math.Clamp(requestedEndByte.Value, 0, fileSize - 1);
+        var avgSegmentSize = (double)fileSize / fileSegmentIds.Length;
+        if (avgSegmentSize <= 0) return null;
+
+        var absoluteEndIndex = Math.Clamp(
+            (int)(endByte / avgSegmentSize), 0, fileSegmentIds.Length - 1);
+        var withOvershoot = absoluteEndIndex + RangePrefetchOvershootSegments;
+        var relativeCount = withOvershoot - firstSegmentIndex + 1;
+        if (relativeCount <= 0) return 0;
+        if (relativeCount >= remainingSegmentCount) return null;
+        return relativeCount;
     }
 
     protected override void Dispose(bool disposing)

--- a/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
+++ b/backend/WebDav/Base/GetAndHeadHandlerPatch.cs
@@ -48,6 +48,12 @@ public class GetAndHeadHandlerPatch : IRequestHandler
         // Determine the requested range
         var range = request.GetRange();
 
+        // Forward closed-range end byte to downstream prefetch capping.
+        if (range?.End is long requestedRangeEnd)
+        {
+            httpContext.Items["RequestedRangeEnd"] = requestedRangeEnd;
+        }
+
         // Obtain the WebDAV collection
         var entry = await _store.GetItemAsync(request.GetUri(), httpContext.RequestAborted).ConfigureAwait(false);
         if (entry == null)

--- a/backend/WebDav/DatabaseStoreMultipartFile.cs
+++ b/backend/WebDav/DatabaseStoreMultipartFile.cs
@@ -37,10 +37,18 @@ public class DatabaseStoreMultipartFile(
 
     private Stream GetStream(DavMultipartFile multipartFile)
     {
+        // Closed-range end byte from GetAndHeadHandlerPatch, used to cap prefetch.
+        // Skip it for AES files: the Range is in decrypted coordinates, which don't map
+        // onto the encrypted packed stream this caps.
+        var requestedEndByte = multipartFile.Metadata.AesParams == null
+            ? httpContext.Items["RequestedRangeEnd"] as long?
+            : null;
+
         var packedStream = new DavMultipartFileStream(
             multipartFile.Metadata.FileParts,
             usenetClient,
-            configManager.GetArticleBufferSize()
+            configManager.GetArticleBufferSize(),
+            requestedEndByte
         );
 
         return multipartFile.Metadata.AesParams != null

--- a/backend/WebDav/DatabaseStoreNzbFile.cs
+++ b/backend/WebDav/DatabaseStoreNzbFile.cs
@@ -36,6 +36,9 @@ public class DatabaseStoreNzbFile(
 
     private NzbFileStream GetStream(DavNzbFile nzbFile)
     {
-        return usenetClient.GetFileStream(nzbFile.SegmentIds, FileSize, configManager.GetArticleBufferSize());
+        // Closed-range end byte from GetAndHeadHandlerPatch, used to cap prefetch.
+        var requestedEndByte = httpContext.Items["RequestedRangeEnd"] as long?;
+        return usenetClient.GetFileStream(
+            nzbFile.SegmentIds, FileSize, configManager.GetArticleBufferSize(), requestedEndByte);
     }
 }

--- a/backend/WebDav/DatabaseStoreRarFile.cs
+++ b/backend/WebDav/DatabaseStoreRarFile.cs
@@ -37,11 +37,14 @@ public class DatabaseStoreRarFile(
 
     private DavMultipartFileStream GetStream(DavRarFile rarFile)
     {
+        // Closed-range end byte from GetAndHeadHandlerPatch, used to cap prefetch.
+        var requestedEndByte = httpContext.Items["RequestedRangeEnd"] as long?;
         return new DavMultipartFileStream
         (
             rarFile.ToDavMultipartFileMeta().FileParts,
             usenetClient,
-            configManager.GetArticleBufferSize()
+            configManager.GetArticleBufferSize(),
+            requestedEndByte
         );
     }
 }


### PR DESCRIPTION
This change improves stuttering/stalling during playback with two changes:

- Raises the default connection idle timeout from 30 seconds to 120 seconds (and makes it configurable). The previous setting was too aggressive, connections in the pool were being disposed during inter-chunk gaps, forcing reconnect costs (TCP + TLS + AUTH) on every chunk request and stalling playback while nzbdav waited for new connections to come up. 120s is right under the cap where most providers start killing idle connections (150s-180s in my testing).
- Caps prefetch at the requested HTTP Range end + 4 articles. Without the cap, nzbdav was fetching up to usenet.article-buffer-size extra articles past what rclone requested (default 40, ~28 MB per chunk) then discarding them on stream close. For chunk fetches this means ~20% wasted RX at upstream defaults (more at higher buffer sizes); for small Range requests like Plex's Background Media Analyzer (which can't be disabled) probes the waste was much larger, sometimes hundreds of MB per probe. This did have the side effect of holding connections open longer, which reduced stuttering, which is why it's combined with the idle timeout change.