### PR TITLE
Pipeline STAT article-health checks (on-add + background)

### DIFF
--- a/backend/Api/Controllers/TestUsenetPipelining/TestUsenetPipeliningController.cs
+++ b/backend/Api/Controllers/TestUsenetPipelining/TestUsenetPipeliningController.cs
@@ -1,0 +1,77 @@
+using Microsoft.AspNetCore.Mvc;
+using NzbWebDAV.Api.Controllers.TestUsenetConnection;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Exceptions;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Api.Controllers.TestUsenetPipelining;
+
+[ApiController]
+[Route("api/test-usenet-pipelining")]
+public class TestUsenetPipeliningController() : BaseApiController
+{
+    // A small probe is enough to tell whether the server tolerates pipelined STAT. We send a
+    // handful of commands at once; servers that don't support pipelining stall, drop the
+    // connection, or desync rather than answering all of them in order.
+    private const int ProbeBatchSize = 5;
+
+    private async Task<TestUsenetPipeliningResponse> TestPipelining(TestUsenetConnectionRequest request)
+    {
+        INntpClient connection;
+        try
+        {
+            connection = await UsenetStreamingClient
+                .CreateNewConnection(request.ToConnectionDetails(), HttpContext.RequestAborted)
+                .ConfigureAwait(false);
+        }
+        catch (CouldNotConnectToUsenetException)
+        {
+            return new TestUsenetPipeliningResponse { Status = true, Connected = false, Supported = false };
+        }
+        catch (CouldNotLoginToUsenetException)
+        {
+            return new TestUsenetPipeliningResponse { Status = true, Connected = false, Supported = false };
+        }
+
+        try
+        {
+            // STAT a batch of randomly-generated, non-existent message-ids. These have no side
+            // effects and every server answers each with a 430. If we get the expected number of
+            // 430s back, the server accepted the whole pipelined batch and answered in order.
+            var probeIds = GenerateProbeMessageIds(ProbeBatchSize);
+            var results = await connection
+                .StatPipelinedAsync(probeIds, HttpContext.RequestAborted)
+                .ConfigureAwait(false);
+
+            var supported = results.Count == probeIds.Count
+                            && results.All(r => r.ResponseType == UsenetResponseType.NoArticleWithThatMessageId);
+
+            return new TestUsenetPipeliningResponse { Status = true, Connected = true, Supported = supported };
+        }
+        catch (Exception e) when (e is not OperationCanceledException ||
+                                  !HttpContext.RequestAborted.IsCancellationRequested)
+        {
+            // Timeout, dropped connection or protocol desync -> not safe to pipeline this provider.
+            return new TestUsenetPipeliningResponse { Status = true, Connected = true, Supported = false };
+        }
+        finally
+        {
+            connection.Dispose();
+        }
+    }
+
+    private static List<string> GenerateProbeMessageIds(int count)
+    {
+        var ids = new List<string>(count);
+        for (var i = 0; i < count; i++)
+            ids.Add($"nzbdav-pipelining-probe-{Guid.NewGuid():N}@nzbdav.invalid");
+        return ids;
+    }
+
+    protected override async Task<IActionResult> HandleRequest()
+    {
+        var request = new TestUsenetConnectionRequest(HttpContext);
+        var response = await TestPipelining(request).ConfigureAwait(false);
+        return Ok(response);
+    }
+}

--- a/backend/Api/Controllers/TestUsenetPipelining/TestUsenetPipeliningResponse.cs
+++ b/backend/Api/Controllers/TestUsenetPipelining/TestUsenetPipeliningResponse.cs
@@ -1,0 +1,10 @@
+namespace NzbWebDAV.Api.Controllers.TestUsenetPipelining;
+
+public class TestUsenetPipeliningResponse : BaseApiResponse
+{
+    // Whether we could connect + authenticate at all (mirrors the connection test).
+    public bool Connected { get; set; }
+
+    // Whether the provider correctly handled a pipelined STAT batch (in-order, no drop/timeout).
+    public bool Supported { get; set; }
+}

--- a/backend/Clients/Usenet/BaseNntpClient.cs
+++ b/backend/Clients/Usenet/BaseNntpClient.cs
@@ -60,6 +60,18 @@ public class BaseNntpClient : NntpClient
         return _client.StatAsync(segmentId, cancellationToken);
     }
 
+    public override Task<IReadOnlyList<UsenetStatResponse>> StatPipelinedAsync
+    (
+        IReadOnlyList<string> segmentIds,
+        CancellationToken cancellationToken
+    )
+    {
+        var ids = new SegmentId[segmentIds.Count];
+        for (var i = 0; i < segmentIds.Count; i++)
+            ids[i] = segmentIds[i];
+        return _client.StatPipelinedAsync(ids, cancellationToken);
+    }
+
     public override async Task<UsenetHeadResponse> HeadAsync(SegmentId segmentId, CancellationToken cancellationToken)
     {
         var headResponse = await _client.HeadAsync(segmentId, cancellationToken);

--- a/backend/Clients/Usenet/INntpClient.cs
+++ b/backend/Clients/Usenet/INntpClient.cs
@@ -17,6 +17,12 @@ public interface INntpClient : IDisposable
     Task<UsenetStatResponse> StatAsync(
         SegmentId segmentId, CancellationToken cancellationToken);
 
+    // STAT a batch of segments, returning one result per segment in the same order.
+    // Implementations may pipeline the commands (one round-trip for the whole batch) where
+    // the provider supports it, and otherwise fall back to checking them one at a time.
+    Task<IReadOnlyList<UsenetStatResponse>> StatPipelinedAsync(
+        IReadOnlyList<string> segmentIds, CancellationToken cancellationToken);
+
     Task<UsenetHeadResponse> HeadAsync(
         SegmentId segmentId, CancellationToken cancellationToken);
 

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -27,7 +27,8 @@ public class MultiConnectionNntpClient(
     ConnectionPool<INntpClient> connectionPool,
     ProviderType type,
     ProviderCircuitBreaker circuitBreaker,
-    string providerName
+    string providerName,
+    bool statPipeliningEnabled = false
 ) : NntpClient
 {
     public ProviderType ProviderType { get; } = type;
@@ -57,6 +58,95 @@ public class MultiConnectionNntpClient(
             onConnectionReadyAgain: null,
             ct
         );
+    }
+
+    public override async Task<IReadOnlyList<UsenetStatResponse>> StatPipelinedAsync
+    (
+        IReadOnlyList<string> segmentIds,
+        CancellationToken ct
+    )
+    {
+        if (segmentIds.Count == 0) return [];
+
+        var retryCount = 1;
+        while (true)
+        {
+            ConnectionLock<INntpClient>? connectionLock = null;
+            try
+            {
+                connectionLock = await connectionPool
+                    .GetConnectionLockAsync(SemaphorePriority.Low, ct).ConfigureAwait(false);
+            }
+            catch (Exception e) when (e.IsCancellationException())
+            {
+                LogException(() => connectionLock?.Dispose());
+                throw;
+            }
+            catch (Exception e)
+            {
+                circuitBreaker.RecordFailure();
+                LogException(() => connectionLock?.Replace());
+                LogException(() => connectionLock?.Dispose());
+                if (retryCount-- > 0)
+                {
+                    Log.Debug(e, "Error getting connection-lock for provider {Provider}. Retrying with a new connection.", providerName);
+                    continue;
+                }
+
+                Log.Warning(e, "Error getting connection-lock for provider {Provider}.", providerName);
+                throw;
+            }
+
+            try
+            {
+                IReadOnlyList<UsenetStatResponse> results;
+                if (statPipeliningEnabled)
+                {
+                    // One round-trip for the whole batch on this single borrowed connection.
+                    results = await connectionLock.Connection
+                        .StatPipelinedAsync(segmentIds, ct).ConfigureAwait(false);
+                }
+                else
+                {
+                    // Provider hasn't opted into pipelining: check the batch linearly, but still
+                    // on this one connection so the batch keeps its place in the pool.
+                    var linear = new UsenetStatResponse[segmentIds.Count];
+                    for (var i = 0; i < segmentIds.Count; i++)
+                        linear[i] = await connectionLock.Connection
+                            .StatAsync(segmentIds[i], ct).ConfigureAwait(false);
+                    results = linear;
+                }
+
+                circuitBreaker.RecordSuccess();
+                LogException(() => connectionLock?.Dispose());
+                return results;
+            }
+            catch (Exception e) when (e.IsCancellationException())
+            {
+                // A cancelled batch (e.g. CheckAllSegmentsAsync failing fast on a missing article)
+                // may have written commands with responses still unread, leaving the stream desynced
+                // and the connection poisoned. Discard it rather than return it to the pool.
+                LogException(() => connectionLock?.Replace());
+                LogException(() => connectionLock?.Dispose());
+                throw;
+            }
+            catch (Exception e)
+            {
+                circuitBreaker.RecordFailure();
+                // A failed pipelined batch leaves the connection's stream in an indeterminate
+                // state, so discard it (Replace) rather than returning it to the pool.
+                LogException(() => connectionLock?.Replace());
+                LogException(() => connectionLock?.Dispose());
+                if (retryCount-- > 0)
+                {
+                    Log.Debug(e, "Error executing pipelined STAT batch for provider {Provider}. Retrying with a new connection.", providerName);
+                    continue;
+                }
+
+                Log.Warning(e, "Error executing pipelined STAT batch for provider {Provider}.", providerName);
+                throw;
+            }
+        }
     }
 
     public override Task<UsenetHeadResponse> HeadAsync(SegmentId segmentId, CancellationToken ct)

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -24,6 +24,76 @@ public class MultiProviderNntpClient(List<MultiConnectionNntpClient> providers) 
         return RunFromPoolWithBackup(x => x.StatAsync(segmentId, cancellationToken), cancellationToken);
     }
 
+    public override async Task<IReadOnlyList<UsenetStatResponse>> StatPipelinedAsync
+    (
+        IReadOnlyList<string> segmentIds,
+        CancellationToken cancellationToken
+    )
+    {
+        if (segmentIds.Count == 0) return [];
+
+        // Same semantics as running each STAT through RunFromPoolWithBackup individually: a segment
+        // is only "missing" if it is missing on every provider. We send the batch to the first
+        // provider, then re-query just the still-missing segments on each subsequent provider.
+        var results = new UsenetStatResponse?[segmentIds.Count];
+        var pending = new List<int>(segmentIds.Count);
+        for (var i = 0; i < segmentIds.Count; i++) pending.Add(i);
+
+        ExceptionDispatchInfo? lastException = null;
+        var orderedProviders = GetOrderedProviders();
+        foreach (var provider in orderedProviders)
+        {
+            if (pending.Count == 0) break;
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (lastException is not null)
+            {
+                var msg = lastException.SourceException.Message;
+                Log.Debug($"Encountered error during pipelined STAT batch: `{msg}`. Trying another provider.");
+            }
+
+            var subBatch = pending.Select(i => segmentIds[i]).ToList();
+            IReadOnlyList<UsenetStatResponse> subResults;
+            try
+            {
+                subResults = await provider.StatPipelinedAsync(subBatch, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e) when (!e.IsCancellationException())
+            {
+                // The whole sub-batch is unresolved on this provider; leave those segments pending
+                // so the next provider gets a chance at them.
+                lastException = ExceptionDispatchInfo.Capture(e);
+                continue;
+            }
+
+            var stillPending = new List<int>();
+            for (var k = 0; k < pending.Count; k++)
+            {
+                var idx = pending[k];
+                var result = subResults[k];
+                results[idx] = result;
+                // Only keep re-querying segments this provider says are missing.
+                if (result.ResponseType == UsenetResponseType.NoArticleWithThatMessageId)
+                    stillPending.Add(idx);
+            }
+
+            pending = stillPending;
+        }
+
+        // Any segment that never received a result only failed because providers threw -- surface
+        // that as an error rather than silently reporting the article as missing.
+        for (var i = 0; i < results.Length; i++)
+        {
+            if (results[i] is null)
+            {
+                if (lastException is not null) lastException.Throw();
+                throw new Exception("There are no usenet providers configured.");
+            }
+        }
+
+        return results!;
+    }
+
     public override Task<UsenetHeadResponse> HeadAsync(SegmentId segmentId, CancellationToken cancellationToken)
     {
         return RunFromPoolWithBackup(x => x.HeadAsync(segmentId, cancellationToken), cancellationToken);

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -105,6 +105,23 @@ public abstract class NntpClient : INntpClient
         return new NzbFileStream(segmentIds, fileSize, this, articleBufferSize);
     }
 
+    /// <summary>
+    /// Default linear implementation: STAT each segment one at a time on this client.
+    /// Layers that can do better (a raw connection that pipelines, or a pool/provider that
+    /// borrows a single connection for the batch) override this.
+    /// </summary>
+    public virtual async Task<IReadOnlyList<UsenetStatResponse>> StatPipelinedAsync
+    (
+        IReadOnlyList<string> segmentIds,
+        CancellationToken cancellationToken
+    )
+    {
+        var results = new UsenetStatResponse[segmentIds.Count];
+        for (var i = 0; i < segmentIds.Count; i++)
+            results[i] = await StatAsync(segmentIds[i], cancellationToken).ConfigureAwait(false);
+        return results;
+    }
+
     public virtual async Task CheckAllSegmentsAsync
     (
         IEnumerable<string> segmentIds,

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -1,14 +1,21 @@
 ﻿using NzbWebDAV.Clients.Usenet.Connections;
 using NzbWebDAV.Config;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Websocket;
+using UsenetSharp.Models;
 
 namespace NzbWebDAV.Clients.Usenet;
 
 public class UsenetStreamingClient : WrappingNntpClient
 {
+    private readonly ConfigManager _configManager;
+
     public UsenetStreamingClient(ConfigManager configManager, WebsocketManager websocketManager)
         : base(CreateDownloadingNntpClient(configManager, websocketManager))
     {
+        _configManager = configManager;
+
         // when config changes, create a new MultiProviderClient to use instead.
         configManager.OnConfigChanged += (_, configEventArgs) =>
         {
@@ -19,6 +26,60 @@ public class UsenetStreamingClient : WrappingNntpClient
             var newUsenetClient = CreateDownloadingNntpClient(configManager, websocketManager);
             ReplaceUnderlyingClient(newUsenetClient);
         };
+    }
+
+    /// <summary>
+    /// STAT-checks every segment, failing fast on the first one that is missing on all providers.
+    /// When the NNTP pipelining master switch is on, segments are checked in pipelined batches
+    /// (per-provider pipelining is gated further down the chain); otherwise this defers to the
+    /// base one-command-per-round-trip implementation.
+    /// </summary>
+    public override async Task CheckAllSegmentsAsync
+    (
+        IEnumerable<string> segmentIds,
+        int concurrency,
+        IProgress<int>? progress,
+        CancellationToken cancellationToken
+    )
+    {
+        // Stay on the original one-at-a-time path unless pipelining is switched on AND at least one
+        // provider has actually opted in -- so enabling the master switch alone changes nothing until
+        // a provider is tested and enabled.
+        var depth = _configManager.GetNntpPipeliningDepth();
+        var anyProviderPipelined = _configManager.GetUsenetProviderConfig()
+            .Providers.Any(p => p.StatPipeliningEnabled);
+        if (!_configManager.GetNntpPipeliningEnabled() || depth <= 1 || !anyProviderPipelined)
+        {
+            await base.CheckAllSegmentsAsync(segmentIds, concurrency, progress, cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        using var childCt = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var token = childCt.Token;
+
+        // Check the segments in pipelined batches of `depth`, running up to `concurrency` batches at
+        // once so every pooled connection stays busy. Depth is the user-facing lever: a deeper
+        // pipeline hides more round-trip latency; if a provider handles deep batches poorly, lower it.
+        var batches = segmentIds.Chunk(depth);
+        var tasks = batches
+            .Select(async batch => (
+                Batch: batch,
+                Results: await StatPipelinedAsync(batch, token).ConfigureAwait(false)
+            ))
+            .WithConcurrencyAsync(concurrency);
+
+        var processed = 0;
+        await foreach (var task in tasks.ConfigureAwait(false))
+        {
+            for (var i = 0; i < task.Batch.Length; i++)
+            {
+                progress?.Report(++processed);
+                if (task.Results[i].ResponseType == UsenetResponseType.ArticleExists) continue;
+                await childCt.CancelAsync().ConfigureAwait(false);
+                throw new UsenetArticleNotFoundException(task.Batch[i]);
+            }
+        }
     }
 
     private static DownloadingNntpClient CreateDownloadingNntpClient
@@ -60,7 +121,12 @@ public class UsenetStreamingClient : WrappingNntpClient
             onConnectionPoolChanged
         );
         var circuitBreaker = new ProviderCircuitBreaker(connectionDetails.Host);
-        return new MultiConnectionNntpClient(connectionPool, connectionDetails.Type, circuitBreaker, connectionDetails.Host);
+        return new MultiConnectionNntpClient(
+            connectionPool,
+            connectionDetails.Type,
+            circuitBreaker,
+            connectionDetails.Host,
+            connectionDetails.StatPipeliningEnabled);
     }
 
     private static ConnectionPool<INntpClient> CreateNewConnectionPool

--- a/backend/Clients/Usenet/WrappingNntpClient.cs
+++ b/backend/Clients/Usenet/WrappingNntpClient.cs
@@ -19,6 +19,21 @@ public class WrappingNntpClient(INntpClient usenetClient) : NntpClient
         SegmentId segmentId, CancellationToken cancellationToken) =>
         _usenetClient.StatAsync(segmentId, cancellationToken);
 
+    public override Task<IReadOnlyList<UsenetStatResponse>> StatPipelinedAsync(
+        IReadOnlyList<string> segmentIds, CancellationToken cancellationToken) =>
+        _usenetClient.StatPipelinedAsync(segmentIds, cancellationToken);
+
+    // Forward to the inner client rather than inheriting NntpClient's base (one-at-a-time)
+    // implementation. Without this, a wrapper such as ArticleCachingNntpClient -- which sits on top
+    // of UsenetStreamingClient during queue processing -- resolves CheckAllSegmentsAsync to the
+    // linear base and never reaches UsenetStreamingClient's pipelined override, so the on-add health
+    // check silently skips pipelining (only the background HealthCheckService, which holds the
+    // UsenetStreamingClient directly, would pipeline).
+    public override Task CheckAllSegmentsAsync(
+        IEnumerable<string> segmentIds, int concurrency, IProgress<int>? progress,
+        CancellationToken cancellationToken) =>
+        _usenetClient.CheckAllSegmentsAsync(segmentIds, concurrency, progress, cancellationToken);
+
     public override Task<UsenetHeadResponse> HeadAsync(
         SegmentId segmentId, CancellationToken cancellationToken) =>
         _usenetClient.HeadAsync(segmentId, cancellationToken);

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -171,6 +171,31 @@ public class ConfigManager
             .ToHashSet();
     }
 
+    /// <summary>
+    /// Master switch for NNTP STAT pipelining. When disabled, STAT health checks always run
+    /// one-command-per-round-trip regardless of any provider's individual pipelining setting.
+    /// </summary>
+    public bool GetNntpPipeliningEnabled()
+    {
+        var defaultValue = true;
+        var configValue = StringUtil.EmptyToNull(GetConfigValue("usenet.nntp-pipelining.enabled"));
+        return (configValue != null ? bool.Parse(configValue) : defaultValue);
+    }
+
+    /// <summary>
+    /// The maximum number of STAT commands sent back-to-back before reading their responses.
+    /// A value of 1 (or less) effectively disables pipelining. Bounded to a conservative range:
+    /// the benefit flattens out well before 150 and higher depths only add provider risk for
+    /// fractions of a second.
+    /// </summary>
+    public int GetNntpPipeliningDepth()
+    {
+        var defaultValue = 50;
+        var configValue = StringUtil.EmptyToNull(GetConfigValue("usenet.nntp-pipelining.depth"));
+        var depth = configValue != null ? int.Parse(configValue) : defaultValue;
+        return Math.Clamp(depth, 1, 150);
+    }
+
     public bool IsPreviewPar2FilesEnabled()
     {
         var defaultValue = false;

--- a/backend/Config/UsenetProviderConfig.cs
+++ b/backend/Config/UsenetProviderConfig.cs
@@ -20,5 +20,10 @@ public class UsenetProviderConfig
         public required string User { get; set; }
         public required string Pass { get; set; }
         public required int MaxConnections { get; set; }
+
+        // Whether STAT existence checks may be pipelined for this provider. Not "required" so
+        // that provider configs saved before this feature existed deserialize to false (i.e.
+        // linear STAT) and only opt in once the user has tested + enabled pipelining.
+        public bool StatPipeliningEnabled { get; set; } = false;
     }
 }

--- a/frontend/app/routes/settings/route.tsx
+++ b/frontend/app/routes/settings/route.tsx
@@ -30,6 +30,8 @@ const defaultConfig = {
     "usenet.max-download-connections": "15",
     "usenet.streaming-priority": "80",
     "usenet.article-buffer-size": "40",
+    "usenet.nntp-pipelining.enabled": "true",
+    "usenet.nntp-pipelining.depth": "50",
     "webdav.user": "admin",
     "webdav.pass": "",
     "webdav.show-hidden-files": "false",

--- a/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
+++ b/frontend/app/routes/settings/sabnzbd/sabnzbd.tsx
@@ -215,6 +215,40 @@ export function SabnzbdSettings({ config, setNewConfig, appVersion }: SabnzbdSet
                 <Form.Check
                     className={styles.input}
                     type="checkbox"
+                    id="nntp-pipelining-enabled-checkbox"
+                    aria-describedby="nntp-pipelining-help"
+                    label={`Use NNTP pipelining for article health checks`}
+                    checked={config["usenet.nntp-pipelining.enabled"] === "true"}
+                    onChange={e => setNewConfig({ ...config, "usenet.nntp-pipelining.enabled": "" + e.target.checked })} />
+                <Form.Text id="nntp-pipelining-help" muted>
+                    Sends STAT existence checks in batches instead of one at a time, speeding up the
+                    on-add and background article health checks. Only applies to providers with
+                    pipelining enabled on the Usenet tab; turn this off to disable it everywhere.
+                </Form.Text>
+                <Form.Label htmlFor="nntp-pipelining-depth-input" style={{ marginTop: '15px' }}>
+                    Pipelining Depth
+                </Form.Label>
+                <Form.Control
+                    className={styles.input}
+                    type="text"
+                    id="nntp-pipelining-depth-input"
+                    aria-describedby="nntp-pipelining-depth-help"
+                    placeholder="50"
+                    value={config["usenet.nntp-pipelining.depth"]}
+                    disabled={config["usenet.nntp-pipelining.enabled"] !== "true"}
+                    isInvalid={!isValidPipeliningDepth(config["usenet.nntp-pipelining.depth"])}
+                    onChange={e => setNewConfig({ ...config, "usenet.nntp-pipelining.depth": e.target.value })} />
+                <Form.Text id="nntp-pipelining-depth-help" muted>
+                    The maximum number of concurrent STAT commands sent.
+                    Higher values reduce round-trips further but may stress some servers, with little
+                    extra benefit past ~100. Must be between 1 and 150.
+                </Form.Text>
+            </Form.Group>
+            <hr />
+            <Form.Group>
+                <Form.Check
+                    className={styles.input}
+                    type="checkbox"
                     id="ignore-history-limit-checkbox"
                     aria-describedby="ignore-history-limit-help"
                     label={`Always send full History to Radarr/Sonarr`}
@@ -327,11 +361,19 @@ export function isSabnzbdSettingsUpdated(config: Record<string, string>, newConf
         || config["api.user-agent"] !== newConfig["api.user-agent"]
         || config["api.nzb-backup-enabled"] !== newConfig["api.nzb-backup-enabled"]
         || config["api.nzb-backup-location"] !== newConfig["api.nzb-backup-location"]
+        || config["usenet.nntp-pipelining.enabled"] !== newConfig["usenet.nntp-pipelining.enabled"]
+        || config["usenet.nntp-pipelining.depth"] !== newConfig["usenet.nntp-pipelining.depth"]
 }
 
 export function isSabnzbdSettingsValid(newConfig: Record<string, string>) {
     return isValidCategories(newConfig["api.categories"])
-        && isValidNzbBackupLocation(newConfig);
+        && isValidNzbBackupLocation(newConfig)
+        && isValidPipeliningDepth(newConfig["usenet.nntp-pipelining.depth"]);
+}
+
+function isValidPipeliningDepth(depth: string): boolean {
+    const value = Number(depth);
+    return Number.isInteger(value) && value >= 1 && value <= 150;
 }
 
 export function generateNewApiKey(): string {

--- a/frontend/app/routes/settings/usenet/usenet.tsx
+++ b/frontend/app/routes/settings/usenet/usenet.tsx
@@ -25,6 +25,7 @@ type ConnectionDetails = {
     User: string;
     Pass: string;
     MaxConnections: number;
+    StatPipeliningEnabled?: boolean;
 };
 
 type ConnectionCounts = {
@@ -275,6 +276,7 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
             <ProviderModal
                 show={showModal}
                 provider={editingIndex !== null ? providerConfig.Providers[editingIndex] : null}
+                pipeliningMasterEnabled={config["usenet.nntp-pipelining.enabled"] === "true"}
                 onClose={handleCloseModal}
                 onSave={handleSaveProvider}
             />
@@ -285,11 +287,12 @@ export function UsenetSettings({ config, setNewConfig }: UsenetSettingsProps) {
 type ProviderModalProps = {
     show: boolean;
     provider: ConnectionDetails | null;
+    pipeliningMasterEnabled: boolean;
     onClose: () => void;
     onSave: (provider: ConnectionDetails) => void;
 };
 
-function ProviderModal({ show, provider, onClose, onSave }: ProviderModalProps) {
+function ProviderModal({ show, provider, pipeliningMasterEnabled, onClose, onSave }: ProviderModalProps) {
     const [host, setHost] = useState(provider?.Host || "");
     const [port, setPort] = useState(provider?.Port?.toString() || "");
     const [useSsl, setUseSsl] = useState(provider?.UseSsl ?? true);
@@ -297,9 +300,20 @@ function ProviderModal({ show, provider, onClose, onSave }: ProviderModalProps) 
     const [pass, setPass] = useState(provider?.Pass || "");
     const [maxConnections, setMaxConnections] = useState(provider?.MaxConnections?.toString() || "");
     const [type, setType] = useState<ProviderType>(provider?.Type ?? ProviderType.Pooled);
+    const [statPipeliningEnabled, setStatPipeliningEnabled] = useState(provider?.StatPipeliningEnabled ?? false);
     const [isTestingConnection, setIsTestingConnection] = useState(false);
     const [connectionTested, setConnectionTested] = useState(false);
     const [testError, setTestError] = useState<string | null>(null);
+    const [isTestingPipelining, setIsTestingPipelining] = useState(false);
+    const [pipeliningTestResult, setPipeliningTestResult] = useState<"supported" | "unsupported" | null>(null);
+
+    // Editing any connection-identity field invalidates both the connection test and the pipelining
+    // test/opt-in, since both were validated against the previous host/credentials.
+    const invalidateConnectionTests = () => {
+        setConnectionTested(false);
+        setStatPipeliningEnabled(false);
+        setPipeliningTestResult(null);
+    };
 
     // Reset form when modal opens or provider changes
     useEffect(() => {
@@ -311,8 +325,11 @@ function ProviderModal({ show, provider, onClose, onSave }: ProviderModalProps) 
             setPass(provider?.Pass || "");
             setMaxConnections(provider?.MaxConnections?.toString() || "");
             setType(provider?.Type ?? ProviderType.Pooled);
+            setStatPipeliningEnabled(provider?.StatPipeliningEnabled ?? false);
             setConnectionTested(false);
             setTestError(null);
+            setIsTestingPipelining(false);
+            setPipeliningTestResult(null);
         }
     }, [show, provider]);
 
@@ -365,6 +382,45 @@ function ProviderModal({ show, provider, onClose, onSave }: ProviderModalProps) 
         }
     }, [host, port, useSsl, user, pass]);
 
+    const handleTestPipelining = useCallback(async () => {
+        setIsTestingPipelining(true);
+        setPipeliningTestResult(null);
+
+        try {
+            const formData = new FormData();
+            formData.append('host', host);
+            formData.append('port', port);
+            formData.append('use-ssl', useSsl.toString());
+            formData.append('user', user);
+            formData.append('pass', pass);
+
+            const response = await fetch('/api/test-usenet-pipelining', {
+                method: 'POST',
+                body: formData,
+            });
+
+            if (response.ok) {
+                const data = await response.json();
+                if (data.supported) {
+                    // Auto-enable on a successful probe; the user can still untick it manually.
+                    setStatPipeliningEnabled(true);
+                    setPipeliningTestResult("supported");
+                } else {
+                    setStatPipeliningEnabled(false);
+                    setPipeliningTestResult("unsupported");
+                }
+            } else {
+                setStatPipeliningEnabled(false);
+                setPipeliningTestResult("unsupported");
+            }
+        } catch {
+            setStatPipeliningEnabled(false);
+            setPipeliningTestResult("unsupported");
+        } finally {
+            setIsTestingPipelining(false);
+        }
+    }, [host, port, useSsl, user, pass]);
+
     const handleSave = useCallback(() => {
         onSave({
             Type: type,
@@ -374,8 +430,9 @@ function ProviderModal({ show, provider, onClose, onSave }: ProviderModalProps) 
             User: user,
             Pass: pass,
             MaxConnections: parseInt(maxConnections, 10),
+            StatPipeliningEnabled: statPipeliningEnabled,
         });
-    }, [type, host, port, useSsl, user, pass, maxConnections, onSave]);
+    }, [type, host, port, useSsl, user, pass, maxConnections, statPipeliningEnabled, onSave]);
 
     const handleOverlayClick = useCallback((e: React.MouseEvent) => {
         if (e.target === e.currentTarget) {
@@ -419,7 +476,7 @@ function ProviderModal({ show, provider, onClose, onSave }: ProviderModalProps) 
                                 value={host}
                                 onChange={(e) => {
                                     setHost(e.target.value);
-                                    setConnectionTested(false);
+                                    invalidateConnectionTests();
                                 }}
                             />
                         </div>
@@ -436,7 +493,7 @@ function ProviderModal({ show, provider, onClose, onSave }: ProviderModalProps) 
                                 value={port}
                                 onChange={(e) => {
                                     setPort(e.target.value);
-                                    setConnectionTested(false);
+                                    invalidateConnectionTests();
                                 }}
                             />
                         </div>
@@ -453,7 +510,7 @@ function ProviderModal({ show, provider, onClose, onSave }: ProviderModalProps) 
                                 value={user}
                                 onChange={(e) => {
                                     setUser(e.target.value);
-                                    setConnectionTested(false);
+                                    invalidateConnectionTests();
                                 }}
                             />
                         </div>
@@ -470,7 +527,7 @@ function ProviderModal({ show, provider, onClose, onSave }: ProviderModalProps) 
                                 value={pass}
                                 onChange={(e) => {
                                     setPass(e.target.value);
-                                    setConnectionTested(false);
+                                    invalidateConnectionTests();
                                 }}
                             />
                         </div>
@@ -514,12 +571,52 @@ function ProviderModal({ show, provider, onClose, onSave }: ProviderModalProps) 
                                     checked={useSsl}
                                     onChange={(e) => {
                                         setUseSsl(e.target.checked);
-                                        setConnectionTested(false);
+                                        invalidateConnectionTests();
                                     }}
                                 />
                                 <label htmlFor="provider-ssl" className={styles["form-checkbox-label"]}>
                                     Use SSL
                                 </label>
+                            </div>
+                        </div>
+
+                        <div className={`${styles["form-group"]} ${styles["full-width"]}`}>
+                            <div className={styles["form-checkbox-wrapper"]}>
+                                <input
+                                    type="checkbox"
+                                    id="provider-pipelining"
+                                    className={styles["form-checkbox"]}
+                                    checked={statPipeliningEnabled}
+                                    disabled={!pipeliningMasterEnabled}
+                                    onChange={(e) => {
+                                        setStatPipeliningEnabled(e.target.checked);
+                                        setPipeliningTestResult(null);
+                                    }}
+                                />
+                                <label htmlFor="provider-pipelining" className={styles["form-checkbox-label"]}>
+                                    Enable STAT pipelining for this provider
+                                </label>
+                            </div>
+                            <div style={{ marginTop: '8px', display: 'flex', alignItems: 'center', gap: '12px' }}>
+                                <Button
+                                    variant="secondary"
+                                    size="sm"
+                                    onClick={handleTestPipelining}
+                                    disabled={!pipeliningMasterEnabled || !isFormValid || isTestingPipelining}
+                                >
+                                    {isTestingPipelining ? "Testing..." : "Test pipelining support"}
+                                </Button>
+                                {pipeliningTestResult === "supported" && (
+                                    <span style={{ color: 'var(--bs-success, #28a745)' }}>✓ Supported</span>
+                                )}
+                                {pipeliningTestResult === "unsupported" && (
+                                    <span style={{ color: 'var(--bs-danger, #dc3545)' }}>✗ Not supported</span>
+                                )}
+                            </div>
+                            <div style={{ marginTop: '8px', opacity: 0.7, fontSize: '0.85em' }}>
+                                {pipeliningMasterEnabled
+                                    ? "Pipelining sends many STAT checks at once for much faster health checks. Test that this provider handles it correctly before enabling."
+                                    : "To tick “Enable STAT pipelining for this provider”, first turn on the NNTP pipelining master switch on the SABnzbd tab. It’s disabled globally right now."}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
**Depends on nzbdav-dev/UsenetSharp#5** (adds `StatPipelinedAsync`). Opening as a **draft**: the `UsenetSharp` `PackageReference` is intentionally still `1.0.6`, so this won't build until #5 is merged + released and the reference is bumped. Will mark ready then.

## What
Pipelines STAT existence checks for the on-add and background article-health checks, behind a global master switch plus a per-provider opt-in.

## How
- `StatPipelinedAsync` plumbed through the client chain (`INntpClient` → `WrappingNntpClient` → `BaseNntpClient` → `MultiConnectionNntpClient` → `MultiProviderNntpClient` → `UsenetStreamingClient`).
- `MultiConnectionNntpClient` runs the batch on one borrowed connection (linear per-segment fallback for providers not opted in); a cancelled/failed batch discards the connection, since the stream is left indeterminate.
- `MultiProviderNntpClient` re-queries only the still-missing segments on backups (same "missing only if missing everywhere" semantics as the single-STAT path).
- `WrappingNntpClient` forwards `CheckAllSegmentsAsync` to the inner client — without it the on-add path runs through `ArticleCachingNntpClient` and silently falls back to the linear base, never reaching the pipelined override.
- `UsenetStreamingClient.CheckAllSegmentsAsync` runs depth-sized pipelined batches when enabled, else defers to the existing one-at-a-time path.

## Config & UI
- Master switch `usenet.nntp-pipelining.enabled` + `usenet.nntp-pipelining.depth` (1–150, default 50); per-provider `StatPipeliningEnabled` (default off).
- `test-usenet-pipelining` probe endpoint; Settings UI adds the master switch + depth (SABnzbd tab) and a per-provider tickbox + "Test pipelining support" button (Usenet tab).

## Safety
Nothing pipelines until the master switch is on **and** a provider is explicitly opted in (both default off/untested), so existing setups are unchanged.
